### PR TITLE
Added tests and fixes after the tests

### DIFF
--- a/apps/community/Billing/Tests/RenderAllRoutes.php
+++ b/apps/community/Billing/Tests/RenderAllRoutes.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace HubletoApp\Community\Billing\Tests;
+
+class RenderAllRoutes extends \HubletoMain\Core\AppTest
+{
+
+  public function run(): void
+  {
+    $routes = [
+      'billing',
+    ];
+
+    foreach ($routes as $route) {
+      $this->cli->cyan("Rendering route '{$route}'.\n");
+      $this->main->render($route);
+    }
+  }
+
+}

--- a/apps/community/Calendar/Tests/RenderAllRoutes.php
+++ b/apps/community/Calendar/Tests/RenderAllRoutes.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace HubletoApp\Community\Calendar\Tests;
+
+class RenderAllRoutes extends \HubletoMain\Core\AppTest
+{
+
+  public function run(): void
+  {
+    $routes = [
+      'calendar',
+      'calendar/get-calendar-events',
+    ];
+
+    foreach ($routes as $route) {
+      $this->cli->cyan("Rendering route '{$route}'.\n");
+      $this->main->render($route);
+    }
+  }
+
+}

--- a/apps/community/Customers/Calendar.php
+++ b/apps/community/Customers/Calendar.php
@@ -8,10 +8,19 @@ class Calendar extends \HubletoMain\Core\Calendar {
 
   public function loadEvents(array $params = []): array
   {
+    $idCompany = null;
+    $dateStart = null;
+    $dateEnd = null;
+    if (isset($params["idCompany"])) $idCompany = (int) $params["idCompany"];
+    else return [];
 
-    $idCompany = (int) $params["idCompany"];
-    $dateStart = date("Y-m-d H:i:s", strtotime((string) $this->main->params["start"]));
-    $dateEnd = date("Y-m-d H:i:s", strtotime((string) $this->main->params["end"]));
+    if (isset($this->main->params["start"]) && isset($this->main->params["end"])) {
+      $dateStart = date("Y-m-d H:i:s", strtotime((string) $this->main->params["start"]));
+      $dateEnd = date("Y-m-d H:i:s", strtotime((string) $this->main->params["end"]));
+    } else {
+      $dateStart = date("Y-m-d H:i:s");
+      $dateEnd = date("Y-m-d H:i:s", strtotime("tommorow"));
+    }
 
     $mCompanyActivity = new CompanyActivity($this->main);
 

--- a/apps/community/Customers/Controllers/Api/GetCompany.php
+++ b/apps/community/Customers/Controllers/Api/GetCompany.php
@@ -15,27 +15,34 @@ class GetCompany extends \HubletoMain\Core\Controller {
     $companies = null;
     $companyArray = [];
 
-    try {
-      $companies = $mCompany->eloquent->selectRaw("*, name as _LOOKUP");
-      /**
-       * The string needs to be at least two characters long for the search to activate
-       * due to the lookup inputs not clearing the search parameter when empty
-       */
-      if ($this->main->params["search"] != "" && strlen($this->main->params["search"]) > 1) {
-        $companies
-          ->where("name", "LIKE", "%".$this->main->params["search"]."%")
-          ->orWhere("tax_id", "LIKE", "%".$this->main->params["search"]."%")
-          ->orWhere("company_id", "LIKE", "%".$this->main->params["search"]."%")
-          ->orWhere("vat_id", "LIKE", "%".$this->main->params["search"]."%")
-        ;
+    if (isset($this->main->params["search"])) {
+      try {
+        $companies = $mCompany->eloquent->selectRaw("*, name as _LOOKUP");
+        /**
+         * The string needs to be at least two characters long for the search to activate
+         * due to the lookup inputs not clearing the search parameter when empty
+         */
+        if ($this->main->params["search"] != "" && strlen($this->main->params["search"]) > 1) {
+          $companies
+            ->where("name", "LIKE", "%".$this->main->params["search"]."%")
+            ->orWhere("tax_id", "LIKE", "%".$this->main->params["search"]."%")
+            ->orWhere("company_id", "LIKE", "%".$this->main->params["search"]."%")
+            ->orWhere("vat_id", "LIKE", "%".$this->main->params["search"]."%")
+          ;
+        }
+
+        $companies = $companies->get()->toArray();
+
+      } catch (Exception $e) {
+        return [
+          "status" => "failed",
+          "error" => $e
+        ];
       }
-
-      $companies = $companies->get()->toArray();
-
-    } catch (Exception $e) {
+    } else {
       return [
         "status" => "failed",
-        "error" => $e
+        "error" => "Search parameter was not defined."
       ];
     }
 

--- a/apps/community/Customers/Controllers/Api/GetCompanyContacts.php
+++ b/apps/community/Customers/Controllers/Api/GetCompanyContacts.php
@@ -15,10 +15,10 @@ class GetCompanyContacts extends \HubletoMain\Core\Controller {
 
     try {
       $persons = $mPerson->eloquent->selectRaw("*, CONCAT(first_name, ' ', last_name) as _LOOKUP");
-      if ((int) $this->main->params["id_company"] > 0) {
+      if (isset($this->main->params["id_company"]) && (int) $this->main->params["id_company"] > 0) {
         $persons = $persons->where("id_company", (int) $this->main->params["id_company"]);
       }
-      if ($this->main->params["search"] != "") {
+      if (isset($this->main->params["search"]) && $this->main->params["search"] != "") {
         $persons->whereRaw("CONCAT(first_name, ' ', last_name) LIKE '%".$this->main->params["search"]."%'");
       }
 

--- a/apps/community/Dashboard/Tests/RenderAllRoutes.php
+++ b/apps/community/Dashboard/Tests/RenderAllRoutes.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace HubletoApp\Community\Dashboard\Tests;
+
+class RenderAllRoutes extends \HubletoMain\Core\AppTest
+{
+
+  public function run(): void
+  {
+    $routes = [
+      '',
+    ];
+
+    foreach ($routes as $route) {
+      $this->cli->cyan("Rendering route '{$route}'.\n");
+      $this->main->render($route);
+    }
+  }
+
+}

--- a/apps/community/Deals/Calendar.php
+++ b/apps/community/Deals/Calendar.php
@@ -6,10 +6,19 @@ class Calendar extends \HubletoMain\Core\Calendar {
 
   public function loadEvents(array $params = []): array
   {
+    $idDeal = null;
+    $dateStart = null;
+    $dateEnd = null;
+    if (isset($params["idDeal"])) $idDeal = (int) $params["idDeal"];
+    else return [];
 
-    $idDeal = (int) $params["idDeal"];
-    $dateStart = date("Y-m-d H:i:s", strtotime((string) $params["start"]));
-    $dateEnd = date("Y-m-d H:i:s", strtotime((string) $params["end"]));
+    if (isset($this->main->params["start"]) && isset($this->main->params["end"])) {
+      $dateStart = date("Y-m-d H:i:s", strtotime((string) $this->main->params["start"]));
+      $dateEnd = date("Y-m-d H:i:s", strtotime((string) $this->main->params["end"]));
+    } else {
+      $dateStart = date("Y-m-d H:i:s");
+      $dateEnd = date("Y-m-d H:i:s", strtotime("tommorow"));
+    }
 
     $mDealActivity = new \HubletoApp\Community\Deals\Models\DealActivity($this->main);
 

--- a/apps/community/Deals/Controllers/Api/ChangePipeline.php
+++ b/apps/community/Deals/Controllers/Api/ChangePipeline.php
@@ -15,19 +15,27 @@ class ChangePipeline extends \HubletoMain\Core\Controller
     $mPipelineStep = new PipelineStep($this->main);
     $newPipeline = null;
 
-    try {
-      $newPipeline = $mPipeline->eloquent
-        ->where("id", $this->main->params["idPipeline"])
-        ->with("PIPELINE_STEPS")
-        ->first()
-        ->toArray()
-      ;
-    } catch (Exception $e) {
+    if (isset($this->main->params["idPipeline"])) {
+      try {
+        $newPipeline = $mPipeline->eloquent
+          ->where("id", $this->main->params["idPipeline"])
+          ->with("PIPELINE_STEPS")
+          ->first()
+          ->toArray()
+        ;
+      } catch (Exception $e) {
+        return [
+          "status" => "failed",
+          "error" => $e
+        ];
+      }
+    } else {
       return [
         "status" => "failed",
-        "error" => $e
+        "error" => "Pipeline parameter was not defined",
       ];
     }
+
 
     return [
       "newPipeline" => $newPipeline,

--- a/apps/community/Deals/Controllers/Api/ChangePipelineStep.php
+++ b/apps/community/Deals/Controllers/Api/ChangePipelineStep.php
@@ -19,25 +19,32 @@ class ChangePipelineStep extends \HubletoMain\Core\Controller
 
     $step = null;
 
-    try {
-      $deal = $mDeal->eloquent->find($this->main->params["idDeal"]);
-      $deal->id_pipeline_step = $this->main->params["idStep"];
-      $deal->save();
+    if (isset($this->main->params["idDeal"]) && isset($this->main->params["idStep"])) {
+      try {
+        $deal = $mDeal->eloquent->find($this->main->params["idDeal"]);
+        $deal->id_pipeline_step = $this->main->params["idStep"];
+        $deal->save();
 
-      $step = $mPipelineStep->eloquent
-        ->where("id_pipeline", $this->main->params["idPipeline"])
-        ->where("id", $this->main->params["idStep"])
-        ->first()
-      ;
-      $mDealHistory->eloquent->create([
-        "change_date" => date("Y-m-d"),
-        "id_deal" => $deal->id,
-        "description" => "Pipeline step changed to ".$step->name
-      ]);
-    } catch (Exception $e) {
+        $step = $mPipelineStep->eloquent
+          ->where("id_pipeline", $this->main->params["idPipeline"])
+          ->where("id", $this->main->params["idStep"])
+          ->first()
+        ;
+        $mDealHistory->eloquent->create([
+          "change_date" => date("Y-m-d"),
+          "id_deal" => $deal->id,
+          "description" => "Pipeline step changed to ".$step->name
+        ]);
+      } catch (Exception $e) {
+        return [
+          "status" => "failed",
+          "error" => $e
+        ];
+      }
+    } else {
       return [
         "status" => "failed",
-        "error" => $e
+        "error" => "Required parameters were not defined."
       ];
     }
 

--- a/apps/community/Deals/Tests/RenderAllRoutes.php
+++ b/apps/community/Deals/Tests/RenderAllRoutes.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace HubletoApp\Community\Deals\Tests;
+
+class RenderAllRoutes extends \HubletoMain\Core\AppTest
+{
+
+  public function run(): void
+  {
+    $routes = [
+      'deals',
+      'deals/get-calendar-events',
+      'deals/archive',
+      'deals/change-pipeline',
+      'deals/change-pipeline-step',
+      'settings/deal-statuses',
+    ];
+
+    foreach ($routes as $route) {
+      $this->cli->cyan("Rendering route '{$route}'.\n");
+      $this->main->render($route);
+    }
+  }
+
+}

--- a/apps/community/Documents/Tests/RenderAllRoutes.php
+++ b/apps/community/Documents/Tests/RenderAllRoutes.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace HubletoApp\Community\Documents\Tests;
+
+class RenderAllRoutes extends \HubletoMain\Core\AppTest
+{
+
+  public function run(): void
+  {
+    $routes = [
+      'documents',
+    ];
+
+    foreach ($routes as $route) {
+      $this->cli->cyan("Rendering route '{$route}'.\n");
+      $this->main->render($route);
+    }
+  }
+
+}

--- a/apps/community/Help/Tests/RenderAllRoutes.php
+++ b/apps/community/Help/Tests/RenderAllRoutes.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace HubletoApp\Community\Help\Tests;
+
+class RenderAllRoutes extends \HubletoMain\Core\AppTest
+{
+
+  public function run(): void
+  {
+    $routes = [
+      'help',
+    ];
+
+    foreach ($routes as $route) {
+      $this->cli->cyan("Rendering route '{$route}'.\n");
+      $this->main->render($route);
+    }
+  }
+
+}

--- a/apps/community/Invoices/Tests/RenderAllRoutes.php
+++ b/apps/community/Invoices/Tests/RenderAllRoutes.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace HubletoApp\Community\Invoices\Tests;
+
+class RenderAllRoutes extends \HubletoMain\Core\AppTest
+{
+
+  public function run(): void
+  {
+    $routes = [
+      'invoices',
+    ];
+
+    foreach ($routes as $route) {
+      $this->cli->cyan("Rendering route '{$route}'.\n");
+      $this->main->render($route);
+    }
+  }
+
+}

--- a/apps/community/Leads/Calendar.php
+++ b/apps/community/Leads/Calendar.php
@@ -6,10 +6,19 @@ class Calendar extends \HubletoMain\Core\Calendar {
 
   public function loadEvents(array $params = []): array
   {
+    $idLead = null;
+    $dateStart = null;
+    $dateEnd = null;
+    if (isset($params["idLead"])) $idLead = (int) $params["idLead"];
+    else return [];
 
-    $idLead = (int) $params["idLead"];
-    $dateStart = date("Y-m-d H:i:s", strtotime((string) $params["start"]));
-    $dateEnd = date("Y-m-d H:i:s", strtotime((string) $params["end"]));
+    if (isset($this->main->params["start"]) && isset($this->main->params["end"])) {
+      $dateStart = date("Y-m-d H:i:s", strtotime((string) $this->main->params["start"]));
+      $dateEnd = date("Y-m-d H:i:s", strtotime((string) $this->main->params["end"]));
+    } else {
+      $dateStart = date("Y-m-d H:i:s");
+      $dateEnd = date("Y-m-d H:i:s", strtotime("tommorow"));
+    }
 
     $mLeadActivity = new \HubletoApp\Community\Leads\Models\LeadActivity($this->main);
 

--- a/apps/community/Leads/Controllers/Api/ConvertLead.php
+++ b/apps/community/Leads/Controllers/Api/ConvertLead.php
@@ -18,6 +18,13 @@ class ConvertLead extends \HubletoMain\Core\Controller
 
   public function renderJson(): ?array
   {
+    if (!isset($this->main->params["recordId"])) {
+      return [
+        "status" => "failed",
+        "error" => "The lead for converting was not set"
+      ];
+    }
+
     $leadId = $this->main->params["recordId"];
 
     $mLead = new Lead($this->main);
@@ -104,7 +111,6 @@ class ConvertLead extends \HubletoMain\Core\Controller
       $lead->is_archived = 1;
       $lead->save();
     } catch (Exception $e) {
-
       return [
         "status" => "failed",
         "error" => $e

--- a/apps/community/Leads/Tests/RenderAllRoutes.php
+++ b/apps/community/Leads/Tests/RenderAllRoutes.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace HubletoApp\Community\Leads\Tests;
+
+class RenderAllRoutes extends \HubletoMain\Core\AppTest
+{
+
+  public function run(): void
+  {
+    $routes = [
+      'leads',
+      'leads/get-calendar-events',
+      'leads/archive',
+      'leads/convert-to-deal',
+      'settings/lead-statuses',
+    ];
+
+    foreach ($routes as $route) {
+      $this->cli->cyan("Rendering route '{$route}'.\n");
+      $this->main->render($route);
+    }
+  }
+
+}

--- a/apps/community/Orders/Tests/RenderAllRoutes.php
+++ b/apps/community/Orders/Tests/RenderAllRoutes.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace HubletoApp\Community\Orders\Tests;
+
+class RenderAllRoutes extends \HubletoMain\Core\AppTest
+{
+
+  public function run(): void
+  {
+    $routes = [
+      'orders',
+    ];
+
+    foreach ($routes as $route) {
+      $this->cli->cyan("Rendering route '{$route}'.\n");
+      $this->main->render($route);
+    }
+  }
+
+}

--- a/apps/community/Pipeline/Controllers/Home.php
+++ b/apps/community/Pipeline/Controllers/Home.php
@@ -100,6 +100,7 @@ class Home extends \HubletoMain\Core\Controller {
     ;
 
     foreach ($deals as $key => $deal) {
+      if (empty($deal["TAGS"])) continue;
       $tag = $mTag->eloquent->find($deal["TAGS"][0]["id_tag"])?->toArray();
       $deals[$key]["TAG"] = $tag;
       unset($deals[$key]["TAGS"]);

--- a/apps/community/Pipeline/Tests/RenderAllRoutes.php
+++ b/apps/community/Pipeline/Tests/RenderAllRoutes.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace HubletoApp\Community\Pipeline\Tests;
+
+class RenderAllRoutes extends \HubletoMain\Core\AppTest
+{
+
+  public function run(): void
+  {
+    $routes = [
+      'pipeline',
+    ];
+
+    foreach ($routes as $route) {
+      $this->cli->cyan("Rendering route '{$route}'.\n");
+      $this->main->render($route);
+    }
+  }
+
+}

--- a/apps/community/Products/Tests/RenderAllRoutes.php
+++ b/apps/community/Products/Tests/RenderAllRoutes.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace HubletoApp\Community\Products\Tests;
+
+class RenderAllRoutes extends \HubletoMain\Core\AppTest
+{
+
+  public function run(): void
+  {
+    $routes = [
+      'products',
+      'products/product-groups',
+      'products/suppliers',
+    ];
+
+    foreach ($routes as $route) {
+      $this->cli->cyan("Rendering route '{$route}'.\n");
+      $this->main->render($route);
+    }
+  }
+
+}

--- a/apps/community/Services/Controllers/Api/GetServicePrice.php
+++ b/apps/community/Services/Controllers/Api/GetServicePrice.php
@@ -12,6 +12,13 @@ class GetServicePrice extends \HubletoMain\Core\Controller {
     $mService = new Service($this->main);
     $service = null;
 
+    if (!isset($this->main->params["serviceId"])) {
+      return [
+        "status" => "failed",
+        "error" => "The searched service was not specified"
+      ];
+    }
+
     try {
       $service = $mService->eloquent
         ->where("id", $this->main->params["serviceId"])

--- a/apps/community/Services/Tests/RenderAllRoutes.php
+++ b/apps/community/Services/Tests/RenderAllRoutes.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace HubletoApp\Community\Services\Tests;
+
+class RenderAllRoutes extends \HubletoMain\Core\AppTest
+{
+
+  public function run(): void
+  {
+    $routes = [
+      'services',
+      'services/get-service-price',
+    ];
+
+    foreach ($routes as $route) {
+      $this->cli->cyan("Rendering route '{$route}'.\n");
+      $this->main->render($route);
+    }
+  }
+
+}

--- a/apps/community/Settings/Tests/RenderAllRoutes.php
+++ b/apps/community/Settings/Tests/RenderAllRoutes.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace HubletoApp\Community\Settings\Tests;
+
+class RenderAllRoutes extends \HubletoMain\Core\AppTest
+{
+
+  public function run(): void
+  {
+    $routes = [
+      'settings',
+      'settings/users',
+      'settings/user-roles',
+      'settings/profiles',
+      'settings/general',
+      'settings/tags',
+      'settings/activity-types',
+      'settings/contact-types',
+      'settings/countries',
+      'settings/currencies',
+      'settings/pipelines',
+      'settings/permissions',
+      'settings/invoice-profiles',
+      'settings/config',
+    ];
+
+    foreach ($routes as $route) {
+      $this->cli->cyan("Rendering route '{$route}'.\n");
+      $this->main->render($route);
+    }
+  }
+
+}

--- a/apps/community/Support/Tests/RenderAllRoutes.php
+++ b/apps/community/Support/Tests/RenderAllRoutes.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace HubletoApp\Community\Support\Tests;
+
+class RenderAllRoutes extends \HubletoMain\Core\AppTest
+{
+
+  public function run(): void
+  {
+    $routes = [
+      'support',
+    ];
+
+    foreach ($routes as $route) {
+      $this->cli->cyan("Rendering route '{$route}'.\n");
+      $this->main->render($route);
+    }
+  }
+
+}

--- a/apps/community/Upgrade/Controllers/Upgrade.php
+++ b/apps/community/Upgrade/Controllers/Upgrade.php
@@ -8,7 +8,7 @@ class Upgrade extends \HubletoMain\Core\Controller {
   {
     parent::prepareView();
 
-    if ($this->main->params['simulate'] == 'up') {
+    if (isset($this->main->params['simulate']) && $this->main->params['simulate'] == 'up') {
       file_put_contents($this->main->config['accountDir'] . '/pro', '1');
       $this->main->router->redirectTo('');
     }

--- a/apps/community/Upgrade/Controllers/YouArePro.php
+++ b/apps/community/Upgrade/Controllers/YouArePro.php
@@ -8,7 +8,7 @@ class YouArePro extends \HubletoMain\Core\Controller {
   {
     parent::prepareView();
 
-    if ($this->main->params['simulate'] == 'down') {
+    if (isset($this->main->params['simulate']) && $this->main->params['simulate'] == 'down') {
       @unlink($this->main->config['accountDir'] . '/pro');
       $this->main->router->redirectTo('');
     }

--- a/apps/community/Upgrade/Tests/RenderAllRoutes.php
+++ b/apps/community/Upgrade/Tests/RenderAllRoutes.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace HubletoApp\Community\Upgrade\Tests;
+
+class RenderAllRoutes extends \HubletoMain\Core\AppTest
+{
+
+  public function run(): void
+  {
+    $routes = [
+      'upgrade',
+      'you-are-pro',
+    ];
+
+    foreach ($routes as $route) {
+      $this->cli->cyan("Rendering route '{$route}'.\n");
+      $this->main->render($route);
+    }
+  }
+
+}


### PR DESCRIPTION
- Added tests on all the routes specified by all of the community app Loader classes
- Added fixes based on the tests results

A test for the Dashboard app showed error in missing $contentHtml. I believe its because specifying a '' route like in the Loader class of the Dashboard app might be erroneous.

Similarly the Support app has the missing $contentHtml error. This may be because the app is not specified in the Installer class as of now.