### PR TITLE
Request permissions change for inline tables and various changes

### DIFF
--- a/apps/community/Contacts/Components/FormPerson.tsx
+++ b/apps/community/Contacts/Components/FormPerson.tsx
@@ -101,7 +101,7 @@ export default class FormPerson<P, S> extends HubletoForm<FormPersonProps,FormPe
                 <div className='border-l border-gray-200'></div>
                 <div className="w-1/2">
                   {this.inputWrapper('note')}
-                  {showAdditional ? this.inputWrapper('is_active') : null}
+                  {this.inputWrapper('is_active')}
                   {showAdditional ? this.inputWrapper('date_created') : null}
                 </div>
               </div>

--- a/apps/community/Contacts/Components/FormPerson.tsx
+++ b/apps/community/Contacts/Components/FormPerson.tsx
@@ -3,14 +3,13 @@ import { deepObjectMerge, getUrlParam } from 'adios/Helper';
 import HubletoForm, {HubletoFormProps, HubletoFormState} from "../../../../src/core/Components/HubletoForm";
 import InputTags2 from 'adios/Inputs/Tags2';
 import FormInput from 'adios/FormInput';
-/* import TableAddresses from './TableAddresses'; */
 import TableContacts from './TableContacts';
-import moment from 'moment';
 import Lookup from 'adios/Inputs/Lookup';
 
 export interface FormPersonProps extends HubletoFormProps {
   newEntryId?: number,
-  creatingNew: boolean
+  creatingNew: boolean,
+  tableContactsDescription: any
 }
 
 export interface FormPersonState extends HubletoFormState {
@@ -135,7 +134,7 @@ export default class FormPerson<P, S> extends HubletoForm<FormPersonProps,FormPe
                   isInlineEditing={this.state.isInlineEditing}
                   isUsedAsInput={true}
                   readonly={!this.state.isInlineEditing}
-                  descriptionSource="both"
+                  descriptionSource="props"
                   onRowClick={() => this.setState({isInlineEditing: true})}
                   onChange={(table: TableContacts) => {
                     this.updateRecord({ CONTACTS: table.state.data.data });
@@ -143,8 +142,9 @@ export default class FormPerson<P, S> extends HubletoForm<FormPersonProps,FormPe
                   onDeleteSelectionChange={(table: TableContacts) => {
                     this.updateRecord({ CONTACTS: table.state.data.data ?? [] });
                   }}
-                  customEndpointParams={{inForm: true}}
+                  customEndpointParams={{idPerson: R.id}}
                   description={{
+                    permissions: this.props.tableContactsDescription.permissions,
                     columns: {
                       type: {
                         type: 'varchar',

--- a/apps/community/Contacts/Components/TablePersons.tsx
+++ b/apps/community/Contacts/Components/TablePersons.tsx
@@ -2,11 +2,12 @@ import React, { Component } from 'react'
 import Table, { TableProps, TableState } from 'adios/Table';
 import FormPerson, { FormPersonProps, FormPersonState } from './FormPerson';
 import { getUrlParam } from 'adios/Helper';
-import { FormProps } from 'adios/Form';
+import request from 'adios/Request';
 
 interface TablePersonsProps extends TableProps {}
 
 interface TablePersonsState extends TableState {
+  tableContactsDescription?: any,
 }
 
 export default class TablePersons extends Table<TablePersonsProps, TablePersonsState> {
@@ -53,6 +54,20 @@ export default class TablePersons extends Table<TablePersonsProps, TablePersonsS
     }
   }
 
+  onAfterLoadTableDescription(description: any) {
+    request.get(
+      'api/table/describe',
+      {
+        model: 'HubletoApp/Community/Contacts/Models/Contact',
+        idPerson: this.props.recordId ?? description.idPerson,
+      },
+      (description: any) => {
+        this.setState({tableContactsDescription: description} as TablePersonsState);
+      }
+    );
+    return description;
+  }
+
   renderCell(columnName: string, column: any, data: any, options: any) {
     if (data.CONTACTS && data.CONTACTS.length > 0) {
       if (columnName == "virt_email") {
@@ -92,7 +107,8 @@ export default class TablePersons extends Table<TablePersonsProps, TablePersonsS
   }
 
   renderForm(): JSX.Element {
-    let formProps: FormProps = this.getFormProps();
+    let formProps: FormPersonProps = this.getFormProps();
+    formProps.tableContactsDescription = this.state.tableContactsDescription as TablePersonsState;
     return <FormPerson {...formProps}/>;
   }
 }

--- a/apps/community/Contacts/Models/Contact.php
+++ b/apps/community/Contacts/Models/Contact.php
@@ -39,7 +39,7 @@ class Contact extends \HubletoMain\Core\Model
     $description->ui['showHeader'] = true;
     $description->ui['showFooter'] = false;
 
-    if ($this->main->urlParamAsBool('inForm') == true) {
+    if ($this->main->urlParamAsInteger('idPerson') > 0) {
       $description->permissions = [
         'canRead' => $this->main->permissions->granted($this->fullName . ':Read'),
         'canCreate' => $this->main->permissions->granted($this->fullName . ':Create'),
@@ -53,10 +53,4 @@ class Contact extends \HubletoMain\Core\Model
 
     return $description;
   }
-
-  // public function prepareLoadRecordQuery(array $includeRelations = [], int $maxRelationLevel = 0, mixed $query = null, int $level = 0): mixed
-  // {
-  //   $query = parent::prepareLoadRecordQuery($includeRelations, 3, $query, $level);
-  //   return $query;
-  // }
 }

--- a/apps/community/Contacts/Models/Person.php
+++ b/apps/community/Contacts/Models/Person.php
@@ -49,9 +49,9 @@ class Person extends \HubletoMain\Core\Model
     $description->ui['addButtonText'] = $this->translate('Add Contact');
     $description->ui['showHeader'] = true;
     $description->ui['showFooter'] = false;
+
     $description->columns['virt_email'] = ["title" => $this->translate("Emails")];
     $description->columns['virt_number'] = ["title" => $this->translate("Phone Numbers")];
-    unset($description->columns['note']);
 
     //nadstavit aby boli tieto stĺpce posledné
     $tempColumn = $description->columns['date_created'];
@@ -60,6 +60,8 @@ class Person extends \HubletoMain\Core\Model
     $tempColumn = $description->columns['is_active'];
     unset($description->columns['is_active']);
     $description->columns['is_active'] = $tempColumn;
+
+    unset($description->columns['note']);
 
     if ($this->main->urlParamAsInteger('idCustomer') > 0) {
       $description->permissions = [

--- a/apps/community/Customers/Components/FormCustomer.tsx
+++ b/apps/community/Customers/Components/FormCustomer.tsx
@@ -23,6 +23,9 @@ export interface FormCustomerProps extends HubletoFormProps {
   createNewDeal: boolean,
   newEntryId?: number,
   tablePersonsDescription?: any,
+  tableLeadsDescription?: any,
+  tableDealsDescription?: any,
+  tableDocumentsDescription?: any,
 }
 
 interface FormCustomerState extends HubletoFormState {
@@ -362,6 +365,9 @@ export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, F
                         },
                       }}
                       onRowClick={(table: TablePersons, row: any) => {
+                        var tableProps = this.props.tablePersonsDescription
+                        tableProps.idPerson = row.id;
+                        table.onAfterLoadTableDescription(tableProps)
                         table.openForm(row.id);
                       }}
                       onChange={(table: TablePersons) => {
@@ -417,11 +423,12 @@ export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, F
               <TableLeads
                 uid={this.props.uid + "_table_leads"}
                 data={{ data: R.LEADS }}
-                descriptionSource="both"
+                descriptionSource="props"
                 customEndpointParams={{idCustomer: R.id}}
                 isUsedAsInput={false}
                 readonly={!this.state.isInlineEditing}
                 description={{
+                  permissions: this.props.tableLeadsDescription.permissions,
                   columns: {
                     title: { type: "varchar", title: "Title" },
                     price: { type: "float", title: "Amount" },
@@ -459,11 +466,12 @@ export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, F
               <TableDeals
                 uid={this.props.uid + "_table_deals"}
                 data={{ data: R.DEALS }}
-                descriptionSource="both"
+                descriptionSource="props"
                 customEndpointParams={{idCustomer: R.id}}
                 isUsedAsInput={false}
                 readonly={!this.state.isInlineEditing}
                 description={{
+                  permissions: this.props.tableDealsDescription.permissions,
                   columns: {
                     title: { type: "varchar", title: "Title" },
                     price: { type: "float", title: "Amount" },
@@ -505,11 +513,12 @@ export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, F
               <TableCustomerDocuments
                 uid={this.props.uid + "_table_deals"}
                 data={{ data: R.DOCUMENTS }}
-                descriptionSource="both"
+                descriptionSource="props"
                 customEndpointParams={{idCustomer: R.id}}
                 isUsedAsInput={true}
                 readonly={!this.state.isInlineEditing}
                 description={{
+                  permissions: this.props.tableDocumentsDescription.permissions,
                   ui: {
                     showFooter: false,
                     showHeader: false,

--- a/apps/community/Customers/Components/TableCustomers.tsx
+++ b/apps/community/Customers/Components/TableCustomers.tsx
@@ -9,7 +9,10 @@ interface TableCustomersProps extends TableProps {
 }
 
 interface TableCustomersState extends TableState {
-  tablePersonsDescription: any
+  tablePersonsDescription?: any,
+  tableLeadsDescription?: any,
+  tableDealsDescription?: any,
+  tableDocumentsDescription?: any,
 }
 
 export default class TableCustomers extends Table<TableCustomersProps, TableCustomersState> {
@@ -63,6 +66,36 @@ export default class TableCustomers extends Table<TableCustomersProps, TableCust
         this.setState({tablePersonsDescription: description} as TableCustomersState);
       }
     );
+    request.get(
+      'api/table/describe',
+      {
+        model: 'HubletoApp/Community/Leads/Models/Lead',
+        idCustomer: this.props.recordId,
+      },
+      (description: any) => {
+        this.setState({tableLeadsDescription: description} as TableCustomersState);
+      }
+    );
+    request.get(
+      'api/table/describe',
+      {
+        model: 'HubletoApp/Community/Deals/Models/Deal',
+        idCustomer: this.props.recordId,
+      },
+      (description: any) => {
+        this.setState({tableDealsDescription: description} as TableCustomersState);
+      }
+    );
+    request.get(
+      'api/table/describe',
+      {
+        model: 'HubletoApp/Community/Customers/Models/CustomerDocument',
+        idCustomer: this.props.recordId,
+      },
+      (description: any) => {
+        this.setState({tableDocumentsDescription: description} as TableCustomersState);
+      }
+    );
 
     return description;
   }
@@ -70,6 +103,9 @@ export default class TableCustomers extends Table<TableCustomersProps, TableCust
   renderForm(): JSX.Element {
     let formProps: FormCustomerProps = this.getFormProps() as FormCustomerProps;
     formProps.tablePersonsDescription = this.state.tablePersonsDescription;
+    formProps.tableLeadsDescription = this.state.tableLeadsDescription;
+    formProps.tableDealsDescription = this.state.tableDealsDescription;
+    formProps.tableDocumentsDescription = this.state.tableDocumentsDescription;
     return <FormCustomer {...formProps}/>;
   }
 }

--- a/apps/community/Customers/Models/Eloquent/CustomerDocument.php
+++ b/apps/community/Customers/Models/Eloquent/CustomerDocument.php
@@ -4,7 +4,6 @@ namespace HubletoApp\Community\Customers\Models\Eloquent;
 
 use HubletoApp\Community\Documents\Models\Eloquent\Document;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class CustomerDocument extends \HubletoMain\Core\ModelEloquent
 {

--- a/apps/community/Deals/Components/FormDeal.tsx
+++ b/apps/community/Deals/Components/FormDeal.tsx
@@ -17,6 +17,8 @@ import moment from 'moment';
 
 export interface FormDealProps extends HubletoFormProps {
   newEntryId?: number,
+  tableDealServicesDescription: any,
+  tableDealDocumentsDescription: any,
 }
 
 export interface FormDealState extends HubletoFormState {
@@ -330,9 +332,10 @@ export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealSt
                               uid={this.props.uid + "_table_deal_services"}
                               data={{ data: R.SERVICES }}
                               dealTotal={R.SERVICES && R.SERVICES.length > 0 ? "Total: " + R.price + " " + R.CURRENCY.code : null}
-                              descriptionSource='both'
+                              descriptionSource='props'
                               customEndpointParams={{idDeal: R.id}}
                               description={{
+                                permissions: this.props.tableDealServicesDescription.permissions,
                                 ui: {
                                   showHeader: false,
                                   showFooter: true
@@ -534,8 +537,9 @@ export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealSt
                 uid={this.props.uid + "_table_deal_documents"}
                 data={{ data: R.DOCUMENTS }}
                 customEndpointParams={{idDeal: R.id}}
-                descriptionSource="both"
+                descriptionSource="props"
                 description={{
+                  permissions: this.props.tableDealDocumentsDescription.permissions,
                   ui: {
                     showFooter: false,
                     showHeader: false,

--- a/apps/community/Deals/Components/TableDeals.tsx
+++ b/apps/community/Deals/Components/TableDeals.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import Table, { TableProps, TableState } from 'adios/Table';
-import FormDeal from './FormDeal';
+import FormDeal, { FormDealProps } from './FormDeal';
+import request from 'adios/Request';
 
 interface TableDealsProps extends TableProps {
   showArchive?: boolean,
@@ -8,6 +9,8 @@ interface TableDealsProps extends TableProps {
 
 interface TableDealsState extends TableState {
   showArchive: boolean,
+  tableDealServicesDescription?: any,
+  tableDealDocumentsDescription?: any,
 }
 
 export default class TableDeals extends Table<TableDealsProps, TableDealsState> {
@@ -81,8 +84,35 @@ export default class TableDeals extends Table<TableDealsProps, TableDealsState> 
     }
   }
 
+  onAfterLoadTableDescription(description: any) {
+    request.get(
+      'api/table/describe',
+      {
+        model: 'HubletoApp/Community/Deals/Models/DealService',
+        idDeal: this.props.recordId,
+      },
+      (description: any) => {
+        this.setState({tableDealServicesDescription: description} as TableDealsState);
+      }
+    );
+    request.get(
+      'api/table/describe',
+      {
+        model: 'HubletoApp/Community/Deals/Models/DealDocument',
+        idDeal: this.props.recordId,
+      },
+      (description: any) => {
+        this.setState({tableDealDocumentsDescription: description} as TableDealsState);
+      }
+    );
+
+    return description;
+  }
+
   renderForm(): JSX.Element {
-    let formProps = this.getFormProps();
+    let formProps = this.getFormProps() as FormDealProps;
+    formProps.tableDealServicesDescription = this.state.tableDealServicesDescription;
+    formProps.tableDealDocumentsDescription = this.state.tableDealDocumentsDescription;
     return <FormDeal {...formProps}/>;
   }
 }

--- a/apps/community/Deals/Models/DealDocument.php
+++ b/apps/community/Deals/Models/DealDocument.php
@@ -12,15 +12,15 @@ class DealDocument extends \HubletoMain\Core\Model
   public string $eloquentClass = Eloquent\DealDocument::class;
 
   public array $relations = [
-    'DEAL' => [ self::BELONGS_TO, Deal::class, 'id_deal', 'id' ],
-    'DOCUMENT' => [ self::BELONGS_TO, Document::class, 'id_lookup', 'id' ],
+    'DEAL' => [ self::BELONGS_TO, Deal::class, 'id_lookup', 'id' ],
+    'DOCUMENT' => [ self::BELONGS_TO, Document::class, 'id_document', 'id' ],
   ];
 
   public function describeColumns(): array
   {
     return array_merge(parent::describeColumns(), [
-      'id_deal' => (new Lookup($this, $this->translate('Deal'), Deal::class))->setFkOnUpdate('CASCADE')->setFkOnDelete('SET NULL')->setRequired(),
-      'id_lookup' => (new Lookup($this, $this->translate('Document'), Document::class, 'CASCADE'))->setRequired(),
+      'id_lookup' => (new Lookup($this, $this->translate('Deal'), Deal::class))->setFkOnUpdate('CASCADE')->setFkOnDelete('SET NULL')->setRequired(),
+      'id_document' => (new Lookup($this, $this->translate('Document'), Document::class, 'CASCADE'))->setRequired(),
     ]);
   }
 

--- a/apps/community/Deals/Reports/MonthlyRevenue.php
+++ b/apps/community/Deals/Reports/MonthlyRevenue.php
@@ -19,9 +19,7 @@ class MonthlyRevenue extends \HubletoMain\Core\Report {
       ["field" => "id_customer", "title" => "Customer"],
     ];
     $config['returnWith'] = [
-      "total" => [
-        ["field" => "price", "title" => "Total price of deals"],
-      ],
+      ["type" => "total", "field" => "price", "title" => "Total price of deals"]
     ];
 
     $config["searchGroups"] = [

--- a/apps/community/Leads/Components/FormLead.tsx
+++ b/apps/community/Leads/Components/FormLead.tsx
@@ -16,6 +16,8 @@ import Hyperlink from 'adios/Inputs/Hyperlink';
 
 export interface FormLeadProps extends HubletoFormProps {
   newEntryId?: number,
+  tableLeadServicesDescription?: any,
+  tableLeadDocumentsDescription?: any,
 }
 
 export interface FormLeadState extends HubletoFormState {
@@ -262,9 +264,10 @@ export default class FormLead<P, S> extends HubletoForm<FormLeadProps,FormLeadSt
                         uid={this.props.uid + "_table_lead_services"}
                         data={{ data: R.SERVICES }}
                         leadTotal={R.SERVICES && R.SERVICES.length > 0 ? "Total: " + R.price + " " + R.CURRENCY.code : "Total: 0 " + R.CURRENCY.code }
-                        descriptionSource='both'
+                        descriptionSource='props'
                         customEndpointParams={{'idLead': R.id}}
                         description={{
+                          permissions: this.props.tableLeadServicesDescription.permissions,
                           ui: {
                             showHeader: false,
                             showFooter: true
@@ -471,7 +474,9 @@ export default class FormLead<P, S> extends HubletoForm<FormLeadProps,FormLeadSt
                 uid={this.props.uid + "_table_lead_document"}
                 data={{ data: R.DOCUMENTS }}
                 descriptionSource="both"
+                customEndpointParams={{idLead: R.id}}
                 description={{
+                  permissions: this.props.tableLeadDocumentsDescription.permissions,
                   ui: {
                     showFooter: false,
                     showHeader: false,

--- a/apps/community/Leads/Components/TableLeads.tsx
+++ b/apps/community/Leads/Components/TableLeads.tsx
@@ -1,7 +1,8 @@
 import React, { Component } from 'react'
 import Table, { TableProps, TableState } from 'adios/Table';
-import FormLead from './FormLead';
+import FormLead, { FormLeadProps } from './FormLead';
 import InputTags2 from 'adios/Inputs/Tags2';
+import request from 'adios/Request';
 
 interface TableLeadsProps extends TableProps {
   showArchive?: boolean,
@@ -9,6 +10,8 @@ interface TableLeadsProps extends TableProps {
 
 interface TableLeadsState extends TableState {
   showArchive: boolean,
+  tableLeadServicesDescription?: any,
+  tableLeadDocumentsDescription?: any,
 }
 
 export default class TableLeads extends Table<TableLeadsProps, TableLeadsState> {
@@ -86,8 +89,34 @@ export default class TableLeads extends Table<TableLeadsProps, TableLeadsState> 
     }
   }
 
+  onAfterLoadTableDescription(description: any) {
+    request.get(
+      'api/table/describe',
+      {
+        model: 'HubletoApp/Community/Leads/Models/LeadService',
+        idLead: this.props.recordId,
+      },
+      (description: any) => {
+        this.setState({tableLeadServicesDescription: description} as TableLeadsState);
+      }
+    );
+    request.get(
+      'api/table/describe',
+      {
+        model: 'HubletoApp/Community/Leads/Models/LeadDocument',
+        idLead: this.props.recordId,
+      },
+      (description: any) => {
+        this.setState({tableLeadDocumentsDescription: description} as TableLeadsState);
+      }
+    );
+    return description;
+  }
+
   renderForm(): JSX.Element {
-    let formProps = this.getFormProps();
+    let formProps = this.getFormProps() as FormLeadProps;
+    formProps.tableLeadServicesDescription = this.state.tableLeadServicesDescription;
+    formProps.tableLeadDocumentsDescription = this.state.tableLeadDocumentsDescription;
     return <FormLead {...formProps}/>;
   }
 }

--- a/apps/community/Orders/Components/FormOrder.tsx
+++ b/apps/community/Orders/Components/FormOrder.tsx
@@ -7,10 +7,12 @@ import Lookup from 'adios/Inputs/Lookup';
 import { TabPanel, TabView } from 'primereact/tabview';
 import TableHistories from './TableHistories';
 
-export interface FormOrderProps extends HubletoFormProps {}
+export interface FormOrderProps extends HubletoFormProps {
+  tableOrderProductsDescription?: any,
+}
 
 export interface FormOrderState extends HubletoFormState {
-  newEntryId: number
+  newEntryId: number,
 }
 
 export default class FormOrder<P, S> extends HubletoForm<FormOrderProps,FormOrderState> {
@@ -122,10 +124,14 @@ export default class FormOrder<P, S> extends HubletoForm<FormOrderProps,FormOrde
                     <TableOrderProducts
                       sum={"Total: " + R.price + " " + R.CURRENCY.code}
                       uid={this.props.uid + "_table_order_products"}
+                      readonly={!this.state.isInlineEditing}
+                      isUsedAsInput={true}
+                      isInlineEditing={this.state.isInlineEditing}
                       data={{ data: R.PRODUCTS }}
                       customEndpointParams={{idOrder: R.id}}
-                      descriptionSource='both'
+                      descriptionSource='props'
                       description={{
+                        permissions: this.props.tableOrderProductsDescription.permissions,
                         ui: {
                           showHeader: false,
                           showFooter: true,
@@ -216,8 +222,6 @@ export default class FormOrder<P, S> extends HubletoForm<FormOrderProps,FormOrde
                           },
                         }
                       }}
-                      isUsedAsInput={true}
-                      isInlineEditing={this.state.isInlineEditing}
                       onRowClick={() => this.setState({isInlineEditing: true})}
                       onChange={(table: TableOrderProducts) => {
                         this.updateRecord({ price: this.getSumPrice( R.PRODUCTS ), PRODUCTS: table.state.data?.data });

--- a/apps/community/Orders/Components/TableOrders.tsx
+++ b/apps/community/Orders/Components/TableOrders.tsx
@@ -1,10 +1,13 @@
 import React, { Component } from 'react'
 import Table, { TableProps, TableState } from 'adios/Table';
-import FormOrder from './FormOrder';
+import FormOrder, { FormOrderProps } from './FormOrder';
+import request from 'adios/Request';
 
 interface TableOrdersProps extends TableProps {}
 
-interface TableOrdersState extends TableState {}
+interface TableOrdersState extends TableState {
+  tableOrderProductsDescription?: any,
+}
 
 export default class TableOrders extends Table<TableOrdersProps, TableOrdersState> {
   static defaultProps = {
@@ -52,8 +55,25 @@ export default class TableOrders extends Table<TableOrdersProps, TableOrdersStat
     return elements;
   }
 
+  onAfterLoadTableDescription(description: any) {
+
+    request.get(
+      'api/table/describe',
+      {
+        model: 'HubletoApp/Community/Orders/Models/OrderProduct',
+        idOrder: this.props.recordId,
+      },
+      (description: any) => {
+        this.setState({tableOrderProductsDescription: description} as TableOrdersState);
+      }
+    );
+
+    return description;
+  }
+
   renderForm(): JSX.Element {
-    let formProps = this.getFormProps();
+    let formProps = this.getFormProps() as FormOrderProps;
+    formProps.tableOrderProductsDescription = this.state.tableOrderProductsDescription;
     return <FormOrder {...formProps}/>;
   }
 }

--- a/apps/community/Reports/Components/FormReport.tsx
+++ b/apps/community/Reports/Components/FormReport.tsx
@@ -212,10 +212,10 @@ export default class FormReport extends Component<FormReportProps,FormReportStat
                 name="types"
                 id="types"
                 className="border p-2 mb-2 mt-2 rounded-md border-gray-200"
-                value={this.props.config.returnWith[Object.keys(this.props.config.returnWith)[0]][0].field}
+                value={this.props.config.returnWith[Object.keys(this.props.config.returnWith)[0]].field}
               >
-                <option value={this.props.config.returnWith[Object.keys(this.props.config.returnWith)[0]][0].field}>
-                  {this.props.config.returnWith[Object.keys(this.props.config.returnWith)[0]][0].title}
+                <option value={this.props.config.returnWith[Object.keys(this.props.config.returnWith)[0]].field}>
+                  {this.props.config.returnWith[Object.keys(this.props.config.returnWith)[0]].title}
                 </option>
               </select>
             </div>

--- a/src/core/Api/GetTemplateChartData.php
+++ b/src/core/Api/GetTemplateChartData.php
@@ -24,23 +24,23 @@ class GetTemplateChartData extends \HubletoMain\Core\Controller
     $model = $this->main->getModel($this->main->urlParamAsString("model"));
 
     $groupBy = $config["groupsBy"][0]["field"];
-    $typeOptions = (array) $config["returnWith"];
+    $returnWith = (array) $config["returnWith"];
 
     $returnData = [];
 
     try {
-      $operation = array_key_first($typeOptions);
+      $operation = $returnWith[0]["type"];
 
       $function = "";
       switch ($operation) {
         case "count":
-          $function = "COUNT(".$typeOptions[$operation][0]["field"].")";
+          $function = "COUNT(".$returnWith[0]["field"].")";
           break;
         case "average":
-          $function = "AVG(".$typeOptions[$operation][0]["field"].")";
+          $function = "AVG(".$returnWith[0]["field"].")";
           break;
         case "total":
-          $function = "SUM(".$typeOptions[$operation][0]["field"].")";
+          $function = "SUM(".$returnWith[0]["field"].")";
           break;
       }
 


### PR DESCRIPTION
- changed how inline tables request their descriptions and permissions 
  - the method before was resulting in the delete button in inline tables to be constantly reloaded (referenced in #53)
-  Added the `Active` button to the new record form for the Person model (referenced in #53)
- refactored the `returnWith` value in the Report app

