### PR TITLE
Add buttons and permission fix

### DIFF
--- a/apps/community/Contacts/Models/Contact.php
+++ b/apps/community/Contacts/Models/Contact.php
@@ -40,7 +40,7 @@ class Contact extends \HubletoMain\Core\Model
     $description->ui['showFulltextSearch'] = true;
     $description->ui['showFooter'] = false;
 
-    if ($this->main->urlParamAsInteger('idPerson') > 0) {
+    if ($this->main->urlParamAsInteger('idPerson') != 0) {
       $description->permissions = [
         'canRead' => $this->main->permissions->granted($this->fullName . ':Read'),
         'canCreate' => $this->main->permissions->granted($this->fullName . ':Create'),

--- a/apps/community/Customers/Components/FormCustomer.tsx
+++ b/apps/community/Customers/Components/FormCustomer.tsx
@@ -16,6 +16,7 @@ import FormDocument, {FormDocumentProps, FormDocumentState} from "../../Document
 import FormPerson, {FormPersonProps, FormPersonState} from "../../Contacts/Components/FormPerson";
 import Calendar from '../../Calendar/Components/Calendar'
 import Hyperlink from "adios/Inputs/Hyperlink";
+import request from "adios/Request";
 
 export interface FormCustomerProps extends HubletoFormProps {
   highlightIdActivity: number,
@@ -38,6 +39,7 @@ interface FormCustomerState extends HubletoFormState {
   showIdActivity: number,
   activityCalendarTimeClicked: string,
   activityCalendarDateClicked: string,
+  tableContactsDescription?: any,
 }
 
 export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, FormCustomerState> {
@@ -91,6 +93,19 @@ export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, F
     }
   }
 
+  onAfterFormInitialized(): void {
+    request.get(
+      'api/table/describe',
+      {
+        model: 'HubletoApp/Community/Contacts/Models/Contact',
+        idPerson: -1,
+      },
+      (description: any) => {
+        this.setState({tableContactsDescription: description} as FormCustomerState);
+      }
+    );
+  }
+
   renderNewPersonForm(R: any): JSX.Element {
     return (
       <ModalSimple
@@ -103,6 +118,7 @@ export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, F
           creatingNew={true}
           isInlineEditing={true}
           descriptionSource="both"
+          tableContactsDescription={this.state.tableContactsDescription}
           description={{
             defaultValues: {
               id_customer: R.id
@@ -330,16 +346,14 @@ export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, F
                 <div className="card" style={{ gridArea: "contacts" }}>
                   <div className="card-header">{this.translate('Contacts')}</div>
                   <div className="card-body">
-                    {this.state.isInlineEditing ? (
-                      <a
-                        role="button"
-                        onClick={() => {
-                          if (!R.PERSONS) R.PERSONS = [];
-                          this.setState({createNewPerson: true} as FormCustomerState);
-                        }}>
-                        + {this.translate('Add contact')}
-                      </a>
-                    ) : null}
+                    <a
+                      role="button"
+                      onClick={() => {
+                        if (!R.PERSONS) R.PERSONS = [];
+                        this.setState({createNewPerson: true} as FormCustomerState);
+                      }}>
+                      + {this.translate('Add contact')}
+                    </a>
                     <TablePersons
                       uid={this.props.uid + "_table_persons"}
                       parentForm={this}
@@ -413,13 +427,11 @@ export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, F
           ) : null}
           {showAdditional ? (
             <TabPanel header={this.translate('Leads')}>
-              {this.state.isInlineEditing ? (
-                <a
-                  role="button"
-                  onClick={() => {this.setState({ createNewLead: true } as FormCustomerState);}}>
-                  + Add Lead
-                </a>
-              ) : <></>}
+              <a
+                role="button"
+                onClick={() => {this.setState({ createNewLead: true } as FormCustomerState);}}>
+                + Add Lead
+              </a>
               <TableLeads
                 uid={this.props.uid + "_table_leads"}
                 data={{ data: R.LEADS }}
@@ -443,6 +455,9 @@ export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, F
                   },
                 }}
                 onRowClick={(table: TableLeads, row: any) => {
+                  var tableProps = this.props.tableLeadsDescription
+                  tableProps.idLead = row.id;
+                  table.onAfterLoadTableDescription(tableProps)
                   table.openForm(row.id);
                 }}
                 onDeleteSelectionChange={(table: TableLeads) => {
@@ -456,13 +471,11 @@ export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, F
           ) : null}
           {showAdditional ? (
             <TabPanel header={this.translate('Deals')}>
-              {this.state.isInlineEditing ? (
-                <a
-                  role="button"
-                  onClick={() => {this.setState({ createNewDeal: true } as FormCustomerState);}}>
-                  + Add Deal
-                </a>
-              ) : <></>}
+              <a
+                role="button"
+                onClick={() => {this.setState({ createNewDeal: true } as FormCustomerState);}}>
+                + Add Deal
+              </a>
               <TableDeals
                 uid={this.props.uid + "_table_deals"}
                 data={{ data: R.DEALS }}
@@ -486,6 +499,9 @@ export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, F
                   },
                 }}
                 onRowClick={(table: TableDeals, row: any) => {
+                  var tableProps = this.props.tableDealsDescription
+                  tableProps.idLead = row.id;
+                  table.onAfterLoadTableDescription(tableProps)
                   table.openForm(row.id);
                 }}
                 onDeleteSelectionChange={(table: TableDeals) => {
@@ -502,14 +518,12 @@ export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, F
               <div className="divider"><div><div><div></div></div><div><span>{this.translate('Shared documents')}</span></div></div></div>
               {this.inputWrapper('shared_folder', {readonly: R.is_archived})}
               <div className="divider"><div><div><div></div></div><div><span>{this.translate('Local documents')}</span></div></div></div>
-              {this.state.isInlineEditing ? (
-                <a
-                  role="button"
-                  onClick={() => this.setState({showIdDocument: -1} as FormCustomerState)}
-                >
-                  + Add Document
-                </a>
-              ) : <></>}
+              <a
+                role="button"
+                onClick={() => this.setState({showIdDocument: -1} as FormCustomerState)}
+              >
+                + Add Document
+              </a>
               <TableCustomerDocuments
                 uid={this.props.uid + "_table_deals"}
                 data={{ data: R.DOCUMENTS }}

--- a/apps/community/Deals/Components/FormDeal.tsx
+++ b/apps/community/Deals/Components/FormDeal.tsx
@@ -312,7 +312,7 @@ export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealSt
                         <div className='card-header'>Services</div>
                         <div className='card-body flex flex-col gap-2'>
                           <div className='w-full h-full overflow-x-auto'>
-                          {this.state.isInlineEditing && !R.is_archived ?
+                          {!R.is_archived ?
                             <a
                               role="button"
                               onClick={() => {
@@ -322,8 +322,7 @@ export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealSt
                                   id_deal: { _useMasterRecordId_: true },
                                   amount: 1
                                 });
-                                this.setState({ record: R });
-                                this.setState({ newEntryId: this.state.newEntryId - 1 } as FormDealState);
+                                this.setState({ record: R, isInlineEditing: true, newEntryId: this.state.newEntryId - 1 } as FormDealState);
                               }}>
                               + Add service
                             </a>
@@ -525,7 +524,7 @@ export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealSt
               <div className="divider"><div><div><div></div></div><div><span>{this.translate('Shared documents')}</span></div></div></div>
               {this.inputWrapper('shared_folder', {readonly: R.is_archived})}
               <div className="divider"><div><div><div></div></div><div><span>{this.translate('Local documents')}</span></div></div></div>
-              {this.state.isInlineEditing  && !R.is_archived ?
+              {!R.is_archived ?
                 <a
                   role="button"
                   onClick={() => this.setState({showIdDocument: -1} as FormDealState)}

--- a/apps/community/Deals/Components/TableDeals.tsx
+++ b/apps/community/Deals/Components/TableDeals.tsx
@@ -89,7 +89,7 @@ export default class TableDeals extends Table<TableDealsProps, TableDealsState> 
       'api/table/describe',
       {
         model: 'HubletoApp/Community/Deals/Models/DealService',
-        idDeal: this.props.recordId,
+        idDeal: this.props.recordId ?? description.idDeal,
       },
       (description: any) => {
         this.setState({tableDealServicesDescription: description} as TableDealsState);
@@ -99,7 +99,7 @@ export default class TableDeals extends Table<TableDealsProps, TableDealsState> 
       'api/table/describe',
       {
         model: 'HubletoApp/Community/Deals/Models/DealDocument',
-        idDeal: this.props.recordId,
+        idDeal: this.props.recordId ?? description.idDeal,
       },
       (description: any) => {
         this.setState({tableDealDocumentsDescription: description} as TableDealsState);

--- a/apps/community/Leads/Components/FormLead.tsx
+++ b/apps/community/Leads/Components/FormLead.tsx
@@ -259,6 +259,21 @@ export default class FormLead<P, S> extends HubletoForm<FormLeadProps,FormLeadSt
                 <div className='card mt-2' style={{gridArea: 'services'}}>
                   <div className='card-header'>Services</div>
                   <div className='card-body flex flex-col gap-2'>
+                    {!R.is_archived ? (
+                      <a
+                        role="button"
+                        onClick={() => {
+                          if (!R.SERVICES) R.SERVICES = [];
+                          R.SERVICES.push({
+                            id: this.state.newEntryId,
+                            id_lead: { _useMasterRecordId_: true },
+                            amount: 1,
+                          });
+                          this.setState({ record: R, isInlineEditing: true, newEntryId: this.state.newEntryId - 1 } as FormLeadState);
+                        }}>
+                        + Add service
+                      </a>
+                    ) : null}
                     <div className='w-full h-full overflow-x-auto'>
                       <TableLeadServices
                         uid={this.props.uid + "_table_lead_services"}
@@ -394,22 +409,6 @@ export default class FormLead<P, S> extends HubletoForm<FormLeadProps,FormLeadSt
                       ></TableLeadServices>
                     </div>
                   </div>
-                    {this.state.isInlineEditing && !R.is_archived ? (
-                      <a
-                        role="button"
-                        onClick={() => {
-                          if (!R.SERVICES) R.SERVICES = [];
-                          R.SERVICES.push({
-                            id: this.state.newEntryId,
-                            id_lead: { _useMasterRecordId_: true },
-                            amount: 1,
-                          });
-                          this.setState({ record: R });
-                          this.setState({ newEntryId: this.state.newEntryId - 1 } as FormLeadState);
-                        }}>
-                        + Add service
-                      </a>
-                    ) : null}
                 </div>
               : null}
             </div>
@@ -470,6 +469,14 @@ export default class FormLead<P, S> extends HubletoForm<FormLeadProps,FormLeadSt
               <div className="divider"><div><div><div></div></div><div><span>{this.translate('Shared documents')}</span></div></div></div>
               {this.inputWrapper('shared_folder', {readonly: R.is_archived})}
               <div className="divider"><div><div><div></div></div><div><span>{this.translate('Local documents')}</span></div></div></div>
+              {!R.is_archived ?
+                <a
+                  role="button"
+                  onClick={() => this.setState({showIdDocument: -1} as FormLeadState)}
+                >
+                  + Add Document
+                </a>
+              : null}
               <TableLeadDocuments
                 uid={this.props.uid + "_table_lead_document"}
                 data={{ data: R.DOCUMENTS }}
@@ -505,14 +512,6 @@ export default class FormLead<P, S> extends HubletoForm<FormLeadProps,FormLeadSt
                   this.setState({showIdDocument: row.id_document} as FormLeadState);
                 }}
               />
-              {this.state.isInlineEditing  && !R.is_archived ?
-                <a
-                  role="button"
-                  onClick={() => this.setState({showIdDocument: -1} as FormLeadState)}
-                >
-                  + Add Document
-                </a>
-              : null}
               {this.state.showIdDocument != 0 ?
                 <ModalSimple
                   uid='document_form'

--- a/apps/community/Leads/Components/TableLeads.tsx
+++ b/apps/community/Leads/Components/TableLeads.tsx
@@ -94,7 +94,7 @@ export default class TableLeads extends Table<TableLeadsProps, TableLeadsState> 
       'api/table/describe',
       {
         model: 'HubletoApp/Community/Leads/Models/LeadService',
-        idLead: this.props.recordId,
+        idLead: this.props.recordId ?? description.idLead,
       },
       (description: any) => {
         this.setState({tableLeadServicesDescription: description} as TableLeadsState);
@@ -104,7 +104,7 @@ export default class TableLeads extends Table<TableLeadsProps, TableLeadsState> 
       'api/table/describe',
       {
         model: 'HubletoApp/Community/Leads/Models/LeadDocument',
-        idLead: this.props.recordId,
+        idLead: this.props.recordId ?? description.idLead,
       },
       (description: any) => {
         this.setState({tableLeadDocumentsDescription: description} as TableLeadsState);


### PR DESCRIPTION
- fix for issue #87 where opening a new contact person form would throw an error due to missing permissions for the contacts table
  - also fixed this issue with opening a lead a deal form in a customer entry
- changed inline table's add buttons to be always shown in forms referenced in #77 and other places