### PR TITLE
Rework of Tags

### DIFF
--- a/apps/community/Calendar/Components/FormActivitySelector.tsx
+++ b/apps/community/Calendar/Components/FormActivitySelector.tsx
@@ -59,7 +59,7 @@ export default class FormActivitySelector<P, S> extends Component<FormActivitySe
                 key={index}
                 className='btn btn-primary w-full !text-center h-[50px] flex justify-center'
                 onClick={() => {
-                  this.setState({formSelected: globalThis.main.renderReactElement(item.form,
+                  this.setState({formSelected: globalThis.main.renderReactElement(item.formComponent,
                     {
                       description: {
                         defaultValues: {

--- a/apps/community/Contacts/Components/FormPerson.tsx
+++ b/apps/community/Contacts/Components/FormPerson.tsx
@@ -86,9 +86,9 @@ export default class FormPerson<P, S> extends HubletoForm<FormPersonProps,FormPe
                     ></Lookup>
                   </FormInput>
                   <FormInput title={this.translate('Tags')}>
-                    <InputTags2 {...this.getInputProps('id_person')}
+                    <InputTags2 {...this.getInputProps()}
                       value={this.state.record.TAGS}
-                      model='HubletoApp/Community/Settings/Models/Tag'
+                      model='HubletoApp/Community/Contacts/Models/Tag'
                       targetColumn='id_person'
                       sourceColumn='id_tag'
                       colorColumn='color'
@@ -110,24 +110,22 @@ export default class FormPerson<P, S> extends HubletoForm<FormPersonProps,FormPe
             <div className='card mt-4' style={{gridArea: 'contacts'}}>
               <div className='card-header'>Contacts</div>
               <div className='card-body'>
-                {this.state.isInlineEditing ? (
-                  <a
-                    className="btn btn-add mb-2"
-                    onClick={() => {
-                      if (!R.CONTACTS) R.CONTACTS = [];
-                      R.CONTACTS.push({
-                        id: this.state.newEntryId,
-                        id_person: { _useMasterRecordId_: true },
-                        type: 'email',
-                      });
-                      this.updateRecord({ CONTACTS: R.CONTACTS });
-                      this.setState({ newEntryId: this.state.newEntryId - 1 } as FormPersonState);
-                    }}
-                  >
-                    <span className="icon"><i className="fas fa-add"></i></span>
-                    <span className="text">{this.translate('Add contact')}</span>
-                  </a>
-                ) : null}
+                <a
+                  className="btn btn-add mb-2"
+                  onClick={() => {
+                    if (!R.CONTACTS) R.CONTACTS = [];
+                    R.CONTACTS.push({
+                      id: this.state.newEntryId,
+                      id_person: { _useMasterRecordId_: true },
+                      type: 'email',
+                    });
+                    this.updateRecord({ CONTACTS: R.CONTACTS });
+                    this.setState({ isInlineEditing: true, newEntryId: this.state.newEntryId - 1 } as FormPersonState);
+                  }}
+                >
+                  <span className="icon"><i className="fas fa-add"></i></span>
+                  <span className="text">{this.translate('Add contact')}</span>
+                </a>
                 <TableContacts
                   uid={this.props.uid + '_table_contacts'}
                   context="Hello World"

--- a/apps/community/Contacts/Components/TablePersons.tsx
+++ b/apps/community/Contacts/Components/TablePersons.tsx
@@ -69,7 +69,15 @@ export default class TablePersons extends Table<TablePersonsProps, TablePersonsS
   }
 
   renderCell(columnName: string, column: any, data: any, options: any) {
-    if (data.CONTACTS && data.CONTACTS.length > 0) {
+    if (columnName == "tags") {
+      return (
+        <>
+          {data.TAGS.map((tag, key) => {
+            return <div style={{backgroundColor: tag.TAG.color}} className='badge'>{tag.TAG.name}</div>;
+          })}
+        </>
+      );
+    } else if (data.CONTACTS && data.CONTACTS.length > 0) {
       if (columnName == "virt_email") {
         let contactsRendered = 0;
         return (

--- a/apps/community/Contacts/Controllers/Tags.php
+++ b/apps/community/Contacts/Controllers/Tags.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace HubletoApp\Community\Settings\Controllers;
+namespace HubletoApp\Community\Contacts\Controllers;
 
 class Tags extends \HubletoMain\Core\Controller {
 
@@ -9,14 +9,14 @@ class Tags extends \HubletoMain\Core\Controller {
   {
     return array_merge(parent::getBreadcrumbs(), [
       [ 'url' => 'settings', 'content' => $this->translate('Settings') ],
-      [ 'url' => 'tags', 'content' => $this->translate('Tags') ],
+      [ 'url' => '', 'content' => $this->translate('Contact Tags') ],
     ]);
   }
 
   public function prepareView(): void
   {
     parent::prepareView();
-    $this->setView('@HubletoApp:Community:Settings/Tags.twig');
+    $this->setView('@HubletoApp:Community:Contacts/Tags.twig');
   }
 
 }

--- a/apps/community/Contacts/Loader.php
+++ b/apps/community/Contacts/Loader.php
@@ -15,7 +15,7 @@ class Loader extends \HubletoMain\Core\App
     $this->main->router->httpGet([
       '/^contacts\/?$/' => Controllers\Persons::class,
       '/^contacts\/get-customer-contacts\/?$/' => Controllers\Api\GetCustomerContacts::class,
-
+      '/^settings\/contact-tags\/?$/' => Controllers\Tags::class,
       '/^settings\/contact-categories\/?$/' => Controllers\ContactCategories::class,
     ]);
 

--- a/apps/community/Contacts/Loader.php
+++ b/apps/community/Contacts/Loader.php
@@ -22,6 +22,11 @@ class Loader extends \HubletoMain\Core\App
     $this->setConfigAsInteger('sidebarOrder', 0);
 
     $this->main->addSetting(['title' => $this->translate('Contact Categories'), 'icon' => 'fas fa-phone', 'url' => 'settings/contact-categories']);
+    $this->main->addSetting([
+      'title' => $this->translate('Contact Tags'),
+      'icon' => 'fas fa-tags',
+      'url' => 'settings/contact-tags',
+    ]);
   }
 
 

--- a/apps/community/Contacts/Models/Eloquent/PersonTag.php
+++ b/apps/community/Contacts/Models/Eloquent/PersonTag.php
@@ -2,7 +2,7 @@
 
 namespace HubletoApp\Community\Contacts\Models\Eloquent;
 
-use HubletoApp\Community\Settings\Models\Eloquent\Tag;
+use HubletoApp\Community\Contacts\Models\Eloquent\Tag;
 
 use \Illuminate\Database\Eloquent\Relations\HasMany;
 use \Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class PersonTag extends \HubletoMain\Core\ModelEloquent
 {
-  public $table = 'person_tags';
+  public $table = 'cross_person_tags';
 
   /** @return BelongsTo<Tag, covariant PersonTag> */
   public function TAG() {

--- a/apps/community/Contacts/Models/Eloquent/Tag.php
+++ b/apps/community/Contacts/Models/Eloquent/Tag.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace HubletoApp\Community\Contacts\Models\Eloquent;
+
+use HubletoApp\Community\Settings\Models\Eloquent\User;
+use \Illuminate\Database\Eloquent\Relations\HasMany;
+use \Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class Tag extends \HubletoMain\Core\ModelEloquent
+{
+  public $table = 'person_tags';
+}

--- a/apps/community/Contacts/Models/Person.php
+++ b/apps/community/Contacts/Models/Person.php
@@ -60,6 +60,7 @@ class Person extends \HubletoMain\Core\Model
     $description->columns['date_created'] = $tempColumn;
     $tempColumn = $description->columns['is_active'];
     unset($description->columns['is_active']);
+    $description->columns['tags'] = ["title" => "Tags"];
     $description->columns['is_active'] = $tempColumn;
 
     unset($description->columns['note']);

--- a/apps/community/Contacts/Models/PersonTag.php
+++ b/apps/community/Contacts/Models/PersonTag.php
@@ -2,13 +2,13 @@
 
 namespace HubletoApp\Community\Contacts\Models;
 
-use HubletoApp\Community\Settings\Models\Tag;
+use HubletoApp\Community\Contacts\Models\Tag;
 
 use \ADIOS\Core\Db\Column\Lookup;
 
 class PersonTag extends \HubletoMain\Core\Model
 {
-  public string $table = 'person_tags';
+  public string $table = 'cross_person_tags';
   public string $eloquentClass = Eloquent\PersonTag::class;
 
   public array $relations = [

--- a/apps/community/Contacts/Models/Tag.php
+++ b/apps/community/Contacts/Models/Tag.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace HubletoApp\Community\Contacts\Models;
+
+use \ADIOS\Core\Db\Column\Varchar;
+use \ADIOS\Core\Db\Column\Color;
+
+class Tag extends \HubletoMain\Core\Model
+{
+  public string $table = 'person_tags';
+  public string $eloquentClass = Eloquent\Tag::class;
+  public ?string $lookupSqlValue = '{%TABLE%}.name';
+
+  public function describeColumns(): array
+  {
+    return array_merge(parent::describeColumns(), [
+      'name' => (new Varchar($this, $this->translate('Name')))->setRequired(),
+      'color' => (new Color($this, $this->translate('Color')))->setRequired(),
+    ]);
+  }
+
+  public function describeTable(): \ADIOS\Core\Description\Table
+  {
+    $description = parent::describeTable();
+
+    $description->ui['title'] = 'Contact Tags';
+    $description->ui['addButtonText'] = 'Add Contact Tag';
+    $description->ui['showHeader'] = true;
+    $description->ui['showFulltextSearch'] = true;
+    $description->ui['showFooter'] = false;
+
+    return $description;
+  }
+
+}

--- a/apps/community/Contacts/Views/Tags.twig
+++ b/apps/community/Contacts/Views/Tags.twig
@@ -1,0 +1,1 @@
+<app-table string:model="HubletoApp/Community/Contacts/Models/Tag"></app-table>

--- a/apps/community/Customers/Components/FormCustomer.tsx
+++ b/apps/community/Customers/Components/FormCustomer.tsx
@@ -322,9 +322,9 @@ export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, F
                     {this.inputWrapper("is_active")}
                     <FormInput title="Tags">
                       <InputTags2
-                        {...this.getInputProps('color_tags')}
+                        {...this.getInputProps()}
                         value={this.state.record.TAGS}
-                        model="HubletoApp/Community/Settings/Models/Tag"
+                        model="HubletoApp/Community/Customers/Models/Tag"
                         targetColumn="id_customer"
                         sourceColumn="id_tag"
                         colorColumn="color"
@@ -374,6 +374,7 @@ export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, F
                           last_name: { type: "varchar", title: this.translate("Last name") },
                           virt_email: { type: "varchar", title: this.translate("Email"), },
                           virt_number: { type: "varchar", title: this.translate("Phone number") },
+                          tags: { type: "none", title: this.translate("Tags") },
                         },
                         inputs: {
                           first_name: { type: "varchar", title: this.translate("First name") },

--- a/apps/community/Customers/Controllers/Tags.php
+++ b/apps/community/Customers/Controllers/Tags.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace HubletoApp\Community\Customers\Controllers;
+
+class Tags extends \HubletoMain\Core\Controller {
+
+
+  public function getBreadcrumbs(): array
+  {
+    return array_merge(parent::getBreadcrumbs(), [
+      [ 'url' => 'settings', 'content' => $this->translate('Settings') ],
+      [ 'url' => '', 'content' => $this->translate('Customer Tags') ],
+    ]);
+  }
+
+  public function prepareView(): void
+  {
+    parent::prepareView();
+    $this->setView('@HubletoApp:Community:Customers/Tags.twig');
+  }
+
+}

--- a/apps/community/Customers/Loader.php
+++ b/apps/community/Customers/Loader.php
@@ -14,6 +14,7 @@ class Loader extends \HubletoMain\Core\App
       '/^customers\/activities\/?$/' => Controllers\Activity::class,
       '/^customers\/get-customer\/?$/' => Controllers\Api\GetCustomer::class,
       '/^customers\/get-calendar-events\/?$/' => Controllers\Api\GetCalendarEvents::class,
+      '/^settings\/customer-tags\/?$/' => Controllers\Tags::class,
     ]);
 
     $this->main->calendarManager->addCalendar(Calendar::class);
@@ -21,28 +22,49 @@ class Loader extends \HubletoMain\Core\App
     $this->main->help->addContextHelpUrls('/^customers\/?$/', [
       'en' => 'en/apps/community/customers',
     ]);
+
+    $this->main->addSetting([
+      'title' => $this->translate('Customer Tags'),
+      'icon' => 'fas fa-tags',
+      'url' => 'settings/customer-tags',
+    ]);
   }
 
   public function installTables(): void
   {
     $mPerson = new \HubletoApp\Community\Contacts\Models\Person($this->main);
     $mContact = new \HubletoApp\Community\Contacts\Models\Contact($this->main);
-    $mPersonTag = new \HubletoApp\Community\Contacts\Models\PersonTag($this->main);
+    $mPersonTag = new \HubletoApp\Community\Contacts\Models\Tag($this->main);
+    $mCrossPersonTag = new \HubletoApp\Community\Contacts\Models\PersonTag($this->main);
 
     $mCustomer = new \HubletoApp\Community\Customers\Models\Customer($this->main);
     $mCustomerActivity = new \HubletoApp\Community\Customers\Models\CustomerActivity($this->main);
     $mCustomerDocument = new \HubletoApp\Community\Customers\Models\CustomerDocument($this->main);
-    $mCustomerTag = new \HubletoApp\Community\Customers\Models\CustomerTag($this->main);
+    $mCustomerTag = new \HubletoApp\Community\Customers\Models\Tag($this->main);
+    $mCrossCustomerTag = new \HubletoApp\Community\Customers\Models\CustomerTag($this->main);
 
     $mCustomer->dropTableIfExists()->install();
     $mPerson->dropTableIfExists()->install();
 
     $mCustomerTag->dropTableIfExists()->install();
+    $mCrossCustomerTag->dropTableIfExists()->install();
     $mCustomerActivity->dropTableIfExists()->install();
     $mCustomerDocument->dropTableIfExists()->install();
 
     $mContact->dropTableIfExists()->install();
     $mPersonTag->dropTableIfExists()->install();
+    $mCrossPersonTag->dropTableIfExists()->install();
+
+    $mCustomerTag->eloquent->create([ 'name' => "VIP", 'color' => '#fc2c03' ]);
+    $mCustomerTag->eloquent->create([ 'name' => "Partner", 'color' => '#62fc03' ]);
+    $mCustomerTag->eloquent->create([ 'name' => "Public", 'color' => '#033dfc' ]);
+
+    $mPersonTag->eloquent->create([ 'name' => "Technical user", 'color' => '#fc2c03' ]);
+    $mPersonTag->eloquent->create([ 'name' => "Business user", 'color' => '#fc7b03' ]);
+    $mPersonTag->eloquent->create([ 'name' => "Desicion Maker", 'color' => '#fcc203' ]);
+    $mPersonTag->eloquent->create([ 'name' => "Partner", 'color' => '#62fc03' ]);
+    $mPersonTag->eloquent->create([ 'name' => "Billing user", 'color' => '#03fc8c' ]);
+    $mPersonTag->eloquent->create([ 'name' => "Other", 'color' => '#033dfc' ]);
 
   }
 

--- a/apps/community/Customers/Models/CustomerTag.php
+++ b/apps/community/Customers/Models/CustomerTag.php
@@ -2,13 +2,13 @@
 
 namespace HubletoApp\Community\Customers\Models;
 
-use HubletoApp\Community\Settings\Models\Tag;
+use HubletoApp\Community\Customers\Models\Tag;
 
 use \ADIOS\Core\Db\Column\Lookup;
 
 class CustomerTag extends \HubletoMain\Core\Model
 {
-  public string $table = 'customer_tags';
+  public string $table = 'cross_customer_tags';
   public string $eloquentClass = Eloquent\CustomerTag::class;
 
   public array $relations = [

--- a/apps/community/Customers/Models/Eloquent/CustomerTag.php
+++ b/apps/community/Customers/Models/Eloquent/CustomerTag.php
@@ -2,7 +2,7 @@
 
 namespace HubletoApp\Community\Customers\Models\Eloquent;
 
-use HubletoApp\Community\Settings\Models\Eloquent\Tag;
+use HubletoApp\Community\Customers\Models\Eloquent\Tag;
 use HubletoApp\Community\Settings\Models\Eloquent\User;
 use \Illuminate\Database\Eloquent\Relations\HasMany;
 use \Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class CustomerTag extends \HubletoMain\Core\ModelEloquent
 {
-  public $table = 'customer_tags';
+  public $table = 'cross_customer_tags';
 
   /** @return BelongsTo<Tag, covariant CustomerTag> */
   public function TAG(): BelongsTo {

--- a/apps/community/Customers/Models/Eloquent/Tag.php
+++ b/apps/community/Customers/Models/Eloquent/Tag.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace HubletoApp\Community\Customers\Models\Eloquent;
+
+use HubletoApp\Community\Settings\Models\Eloquent\User;
+use \Illuminate\Database\Eloquent\Relations\HasMany;
+use \Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class Tag extends \HubletoMain\Core\ModelEloquent
+{
+  public $table = 'customer_tags';
+}

--- a/apps/community/Customers/Models/Tag.php
+++ b/apps/community/Customers/Models/Tag.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace HubletoApp\Community\Customers\Models;
+
+use \ADIOS\Core\Db\Column\Varchar;
+use \ADIOS\Core\Db\Column\Color;
+
+class Tag extends \HubletoMain\Core\Model
+{
+  public string $table = 'customer_tags';
+  public string $eloquentClass = Eloquent\Tag::class;
+  public ?string $lookupSqlValue = '{%TABLE%}.name';
+
+  public function describeColumns(): array
+  {
+    return array_merge(parent::describeColumns(), [
+      'name' => (new Varchar($this, $this->translate('Name')))->setRequired(),
+      'color' => (new Color($this, $this->translate('Color')))->setRequired(),
+    ]);
+  }
+
+  public function describeTable(): \ADIOS\Core\Description\Table
+  {
+    $description = parent::describeTable();
+
+    $description->ui['title'] = 'Customer Tags';
+    $description->ui['addButtonText'] = 'Add Customer Tag';
+    $description->ui['showHeader'] = true;
+    $description->ui['showFulltextSearch'] = true;
+    $description->ui['showFooter'] = false;
+
+    return $description;
+  }
+
+}

--- a/apps/community/Customers/Views/Tags.twig
+++ b/apps/community/Customers/Views/Tags.twig
@@ -1,0 +1,1 @@
+<app-table string:model="HubletoApp/Community/Customers/Models/Tag"></app-table>

--- a/apps/community/Deals/Components/FormDeal.tsx
+++ b/apps/community/Deals/Components/FormDeal.tsx
@@ -262,7 +262,7 @@ export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealSt
                         <InputTags2 {...this.getInputProps()}
                           value={this.state.record.TAGS}
                           readonly={R.is_archived}
-                          model='HubletoApp/Community/Settings/Models/Tag'
+                          model='HubletoApp/Community/Deals/Models/Tag'
                           targetColumn='id_deal'
                           sourceColumn='id_tag'
                           colorColumn='color'

--- a/apps/community/Deals/Controllers/Tags.php
+++ b/apps/community/Deals/Controllers/Tags.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace HubletoApp\Community\Deals\Controllers;
+
+class Tags extends \HubletoMain\Core\Controller {
+
+
+  public function getBreadcrumbs(): array
+  {
+    return array_merge(parent::getBreadcrumbs(), [
+      [ 'url' => 'settings', 'content' => $this->translate('Settings') ],
+      [ 'url' => '', 'content' => $this->translate('Deal Tags') ],
+    ]);
+  }
+
+  public function prepareView(): void
+  {
+    parent::prepareView();
+    $this->setView('@HubletoApp:Community:Deals/Tags.twig');
+  }
+
+}

--- a/apps/community/Deals/Loader.php
+++ b/apps/community/Deals/Loader.php
@@ -16,12 +16,18 @@ class Loader extends \HubletoMain\Core\App
       '/^deals\/change-pipeline\/?$/' => Controllers\Api\ChangePipeline::class,
       '/^deals\/change-pipeline-step\/?$/' => Controllers\Api\ChangePipelineStep::class,
       '/^settings\/deal-statuses\/?$/' => Controllers\DealStatuses::class,
+      '/^settings\/deal-tags\/?$/' => Controllers\Tags::class,
     ]);
 
     $this->main->addSetting([
       'title' => $this->translate('Deal statuses'),
       'icon' => 'fas fa-arrow-up-short-wide',
       'url' => 'settings/deal-statuses',
+    ]);
+    $this->main->addSetting([
+      'title' => $this->translate('Deal Tags'),
+      'icon' => 'fas fa-tags',
+      'url' => 'settings/deal-tags',
     ]);
 
     $this->main->calendarManager->addCalendar(Calendar::class);
@@ -37,7 +43,8 @@ class Loader extends \HubletoMain\Core\App
     $mDealStatus = new Models\DealStatus($this->main);
     $mDeal = new \HubletoApp\Community\Deals\Models\Deal($this->main);
     $mDealHistory = new \HubletoApp\Community\Deals\Models\DealHistory($this->main);
-    $mDealTag = new \HubletoApp\Community\Deals\Models\DealTag($this->main);
+    $mDealTag = new \HubletoApp\Community\Deals\Models\Tag($this->main);
+    $mCrossDealTag = new \HubletoApp\Community\Deals\Models\DealTag($this->main);
     $mDealService = new \HubletoApp\Community\Deals\Models\DealService($this->main);
     $mDealActivity = new \HubletoApp\Community\Deals\Models\DealActivity($this->main);
     $mDealDocument = new \HubletoApp\Community\Deals\Models\DealDocument($this->main);
@@ -46,9 +53,14 @@ class Loader extends \HubletoMain\Core\App
     $mDeal->dropTableIfExists()->install();
     $mDealHistory->dropTableIfExists()->install();
     $mDealTag->dropTableIfExists()->install();
+    $mCrossDealTag->dropTableIfExists()->install();
     $mDealService->dropTableIfExists()->install();
     $mDealActivity->dropTableIfExists()->install();
     $mDealDocument->dropTableIfExists()->install();
+
+    $mDealTag->eloquent->create([ 'name' => "Important", 'color' => '#fc2c03' ]);
+    $mDealTag->eloquent->create([ 'name' => "ASAP", 'color' => '#62fc03' ]);
+    $mDealTag->eloquent->create([ 'name' => "Extenstion", 'color' => '#033dfc' ]);
 
     $mDealStatus->eloquent->create([ 'name' => 'New', 'order' => 1, 'color' => '#0000A0' ]);
     $mDealStatus->eloquent->create([ 'name' => 'In Progress', 'order' => 2, 'color' => '#A0A000' ]);

--- a/apps/community/Deals/Models/DealTag.php
+++ b/apps/community/Deals/Models/DealTag.php
@@ -2,14 +2,14 @@
 
 namespace HubletoApp\Community\Deals\Models;
 
-use HubletoApp\Community\Settings\Models\Tag;
+use HubletoApp\Community\Deals\Models\Tag;
 use HubletoApp\Community\Deals\Models\Deal;
 
 use \ADIOS\Core\Db\Column\Lookup;
 
 class DealTag extends \HubletoMain\Core\Model
 {
-  public string $table = 'deal_tags';
+  public string $table = 'cross_deal_tags';
   public string $eloquentClass = Eloquent\DealTag::class;
 
   public array $relations = [

--- a/apps/community/Deals/Models/Eloquent/DealTag.php
+++ b/apps/community/Deals/Models/Eloquent/DealTag.php
@@ -2,7 +2,7 @@
 
 namespace HubletoApp\Community\Deals\Models\Eloquent;
 
-use HubletoApp\Community\Settings\Models\Eloquent\Tag;
+use HubletoApp\Community\Deals\Models\Eloquent\Tag;
 use HubletoApp\Community\Deals\Models\Eloquent\Deal;
 use \Illuminate\Database\Eloquent\Relations\HasMany;
 use \Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class DealTag extends \HubletoMain\Core\ModelEloquent
 {
-  public $table = 'deal_tags';
+  public $table = 'cross_deal_tags';
 
   /** @return BelongsTo<Deal, covariant DealTag> */
   public function DEAL(): BelongsTo {

--- a/apps/community/Deals/Models/Eloquent/Tag.php
+++ b/apps/community/Deals/Models/Eloquent/Tag.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace HubletoApp\Community\Deals\Models\Eloquent;
+
+use HubletoApp\Community\Settings\Models\Eloquent\User;
+use \Illuminate\Database\Eloquent\Relations\HasMany;
+use \Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class Tag extends \HubletoMain\Core\ModelEloquent
+{
+  public $table = 'deal_tags';
+}

--- a/apps/community/Deals/Models/Tag.php
+++ b/apps/community/Deals/Models/Tag.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace HubletoApp\Community\Deals\Models;
+
+use \ADIOS\Core\Db\Column\Varchar;
+use \ADIOS\Core\Db\Column\Color;
+
+class Tag extends \HubletoMain\Core\Model
+{
+  public string $table = 'deal_tags';
+  public string $eloquentClass = Eloquent\Tag::class;
+  public ?string $lookupSqlValue = '{%TABLE%}.name';
+
+  public function describeColumns(): array
+  {
+    return array_merge(parent::describeColumns(), [
+      'name' => (new Varchar($this, $this->translate('Name')))->setRequired(),
+      'color' => (new Color($this, $this->translate('Color')))->setRequired(),
+    ]);
+  }
+
+  public function describeTable(): \ADIOS\Core\Description\Table
+  {
+    $description = parent::describeTable();
+
+    $description->ui['title'] = 'Deal Tags';
+    $description->ui['addButtonText'] = 'Add Deal Tag';
+    $description->ui['showHeader'] = true;
+    $description->ui['showFulltextSearch'] = true;
+    $description->ui['showFooter'] = false;
+
+    return $description;
+  }
+
+}

--- a/apps/community/Deals/Views/Tags.twig
+++ b/apps/community/Deals/Views/Tags.twig
@@ -1,0 +1,1 @@
+<app-table string:model="HubletoApp/Community/Deals/Models/Tag"></app-table>

--- a/apps/community/Leads/Components/FormLead.tsx
+++ b/apps/community/Leads/Components/FormLead.tsx
@@ -252,7 +252,7 @@ export default class FormLead<P, S> extends HubletoForm<FormLeadProps,FormLeadSt
                       <InputTags2 {...this.getInputProps('tags_input')}
                         value={this.state.record.TAGS}
                         readonly={R.is_archived}
-                        model='HubletoApp/Community/Settings/Models/Tag'
+                        model='HubletoApp/Community/Leads/Models/Tag'
                         targetColumn='id_lead'
                         sourceColumn='id_tag'
                         colorColumn='color'

--- a/apps/community/Leads/Controllers/Tags.php
+++ b/apps/community/Leads/Controllers/Tags.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace HubletoApp\Community\Leads\Controllers;
+
+class Tags extends \HubletoMain\Core\Controller {
+
+
+  public function getBreadcrumbs(): array
+  {
+    return array_merge(parent::getBreadcrumbs(), [
+      [ 'url' => 'settings', 'content' => $this->translate('Settings') ],
+      [ 'url' => '', 'content' => $this->translate('Lead Tags') ],
+    ]);
+  }
+
+  public function prepareView(): void
+  {
+    parent::prepareView();
+    $this->setView('@HubletoApp:Community:Leads/Tags.twig');
+  }
+
+}

--- a/apps/community/Leads/Loader.php
+++ b/apps/community/Leads/Loader.php
@@ -15,12 +15,18 @@ class Loader extends \HubletoMain\Core\App
       '/^leads\/get-calendar-events\/?$/' => Controllers\Api\GetCalendarEvents::class,
       '/^leads\/convert-to-deal\/?$/' => Controllers\Api\ConvertLead::class,
       '/^settings\/lead-statuses\/?$/' => Controllers\LeadStatuses::class,
+      '/^settings\/lead-tags\/?$/' => Controllers\Tags::class,
     ]);
 
     $this->main->addSetting([
       'title' => $this->translate('Lead statuses'),
       'icon' => 'fas fa-arrow-up-short-wide',
       'url' => 'settings/lead-statuses',
+    ]);
+    $this->main->addSetting([
+      'title' => $this->translate('Lead Tags'),
+      'icon' => 'fas fa-tags',
+      'url' => 'settings/lead-tags',
     ]);
 
     $this->main->calendarManager->addCalendar(Calendar::class);
@@ -35,7 +41,8 @@ class Loader extends \HubletoMain\Core\App
     $mLeadStatus = new Models\LeadStatus($this->main);
     $mLead = new \HubletoApp\Community\Leads\Models\Lead($this->main);
     $mLeadHistory = new \HubletoApp\Community\Leads\Models\LeadHistory($this->main);
-    $mLeadTag = new \HubletoApp\Community\Leads\Models\LeadTag($this->main);
+    $mLeadTag = new \HubletoApp\Community\Leads\Models\Tag($this->main);
+    $mCrossLeadTag = new \HubletoApp\Community\Leads\Models\LeadTag($this->main);
     $mLeadService = new \HubletoApp\Community\Leads\Models\LeadService($this->main);
     $mLeadActivity = new \HubletoApp\Community\Leads\Models\LeadActivity($this->main);
     $mLeadDocument = new \HubletoApp\Community\Leads\Models\LeadDocument($this->main);
@@ -44,9 +51,14 @@ class Loader extends \HubletoMain\Core\App
     $mLead->dropTableIfExists()->install();
     $mLeadHistory->dropTableIfExists()->install();
     $mLeadTag->dropTableIfExists()->install();
+    $mCrossLeadTag->dropTableIfExists()->install();
     $mLeadService->dropTableIfExists()->install();
     $mLeadActivity->dropTableIfExists()->install();
     $mLeadDocument->dropTableIfExists()->install();
+
+    $mLeadTag->eloquent->create([ 'name' => "Important", 'color' => '#fc2c03' ]);
+    $mLeadTag->eloquent->create([ 'name' => "ASAP", 'color' => '#62fc03' ]);
+    $mLeadTag->eloquent->create([ 'name' => "Extenstion", 'color' => '#033dfc' ]);
 
     $mLeadStatus->eloquent->create([ 'name' => 'New', 'order' => 1, 'color' => '#f55442' ]);
     $mLeadStatus->eloquent->create([ 'name' => 'In Progress', 'order' => 2, 'color' => '#f5bc42' ]);

--- a/apps/community/Leads/Models/Eloquent/LeadTag.php
+++ b/apps/community/Leads/Models/Eloquent/LeadTag.php
@@ -2,7 +2,7 @@
 
 namespace HubletoApp\Community\Leads\Models\Eloquent;
 
-use HubletoApp\Community\Settings\Models\Eloquent\Tag;
+use HubletoApp\Community\Leads\Models\Eloquent\Tag;
 use HubletoApp\Community\Leads\Models\Eloquent\Lead;
 use \Illuminate\Database\Eloquent\Relations\HasMany;
 use \Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class LeadTag extends \HubletoMain\Core\ModelEloquent
 {
-  public $table = 'lead_tags';
+  public $table = 'cross_lead_tags';
 
   /** @return BelongsTo<Lead, covariant LeadTag> */
   public function LEAD(): BelongsTo {

--- a/apps/community/Leads/Models/Eloquent/Tag.php
+++ b/apps/community/Leads/Models/Eloquent/Tag.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace HubletoApp\Community\Settings\Models\Eloquent;
+namespace HubletoApp\Community\Leads\Models\Eloquent;
 
 use HubletoApp\Community\Settings\Models\Eloquent\User;
 use \Illuminate\Database\Eloquent\Relations\HasMany;
@@ -9,6 +9,5 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class Tag extends \HubletoMain\Core\ModelEloquent
 {
-  public $table = 'tags';
-
+  public $table = 'lead_tags';
 }

--- a/apps/community/Leads/Models/LeadTag.php
+++ b/apps/community/Leads/Models/LeadTag.php
@@ -2,14 +2,14 @@
 
 namespace HubletoApp\Community\Leads\Models;
 
-use HubletoApp\Community\Settings\Models\Tag;
+use HubletoApp\Community\Leads\Models\Tag;
 use HubletoApp\Community\Leads\Models\Lead;
 
 use \ADIOS\Core\Db\Column\Lookup;
 
 class LeadTag extends \HubletoMain\Core\Model
 {
-  public string $table = 'lead_tags';
+  public string $table = 'cross_lead_tags';
   public string $eloquentClass = Eloquent\LeadTag::class;
 
   public array $relations = [

--- a/apps/community/Leads/Models/Tag.php
+++ b/apps/community/Leads/Models/Tag.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace HubletoApp\Community\Settings\Models;
+namespace HubletoApp\Community\Leads\Models;
 
 use \ADIOS\Core\Db\Column\Varchar;
 use \ADIOS\Core\Db\Column\Color;
 
 class Tag extends \HubletoMain\Core\Model
 {
-  public string $table = 'tags';
+  public string $table = 'lead_tags';
   public string $eloquentClass = Eloquent\Tag::class;
   public ?string $lookupSqlValue = '{%TABLE%}.name';
 
@@ -23,8 +23,8 @@ class Tag extends \HubletoMain\Core\Model
   {
     $description = parent::describeTable();
 
-    $description->ui['title'] = 'Tags';
-    $description->ui['addButtonText'] = 'Add Tag';
+    $description->ui['title'] = 'Lead Tags';
+    $description->ui['addButtonText'] = 'Add Lead Tag';
     $description->ui['showHeader'] = true;
     $description->ui['showFulltextSearch'] = true;
     $description->ui['showFooter'] = false;

--- a/apps/community/Leads/Views/Tags.twig
+++ b/apps/community/Leads/Views/Tags.twig
@@ -1,0 +1,1 @@
+<app-table string:model="HubletoApp/Community/Leads/Models/Tag"></app-table>

--- a/apps/community/Settings/Loader.php
+++ b/apps/community/Settings/Loader.php
@@ -28,7 +28,6 @@ class Loader extends \HubletoMain\Core\App
       '/^settings\/user-roles\/?$/' => Controllers\UserRoles::class,
       '/^settings\/profiles\/?$/' => Controllers\Profiles::class,
       '/^settings\/general\/?$/' => Controllers\General::class,
-      '/^settings\/tags\/?$/' => Controllers\Tags::class,
       '/^settings\/activity-types\/?$/' => Controllers\ActivityTypes::class,
       '/^settings\/countries\/?$/' => Controllers\Countries::class,
       '/^settings\/currencies\/?$/' => Controllers\Currencies::class,
@@ -45,7 +44,6 @@ class Loader extends \HubletoMain\Core\App
     $this->main->addSetting(['title' => $this->translate('Your companies'), 'icon' => 'fas fa-id-card', 'url' => 'settings/profiles']);
     $this->main->addSetting(['title' => $this->translate('General settings'), 'icon' => 'fas fa-cog', 'url' => 'settings/general']);
     $this->main->addSetting(['title' => $this->translate('Permissions'), 'icon' => 'fas fa-shield-halved', 'url' => 'settings/permissions']);
-    $this->main->addSetting(['title' => $this->translate('Tags'), 'icon' => 'fas fa-tags', 'url' => 'settings/tags']);
     $this->main->addSetting(['title' => $this->translate('Activity types'), 'icon' => 'fas fa-layer-group', 'url' => 'settings/activity-types']);
     $this->main->addSetting(['title' => $this->translate('Countries'), 'icon' => 'fas fa-globe', 'url' => 'settings/countries']);
     $this->main->addSetting(['title' => $this->translate('Currencies'), 'icon' => 'fas fa-dollar-sign', 'url' => 'settings/currencies']);
@@ -64,11 +62,9 @@ class Loader extends \HubletoMain\Core\App
     $mRolePermission = new Models\RolePermission($this->main);
     $mCountry = new Models\Country($this->main);
     $mSetting = new Models\Setting($this->main);
-    $mTag = new Models\Tag($this->main);
     $mActivityTypes = new Models\ActivityType($this->main);
-    $mContactCategory = new Models\ContactCategory($this->main);
+    $mContactCategory = new \HubletoApp\Community\Contacts\Models\ContactCategory($this->main);
     $mCurrency = new Models\Currency($this->main);
-    $mTag = new Models\Tag($this->main);
     $mPipeline = new Models\Pipeline($this->main);
     $mPipelineStep = new Models\PipelineStep($this->main);
     $mInvoiceProfile = new Models\InvoiceProfile($this->main);
@@ -81,7 +77,6 @@ class Loader extends \HubletoMain\Core\App
     $mRolePermission->dropTableIfExists()->install();
     $mCountry->dropTableIfExists()->install();
     $mSetting->dropTableIfExists()->install();
-    $mTag->dropTableIfExists()->install();
     $mActivityTypes->dropTableIfExists()->install();
     $mContactCategory->dropTableIfExists()->install();
     $mCurrency->dropTableIfExists()->install();
@@ -124,10 +119,6 @@ class Loader extends \HubletoMain\Core\App
     $mContactCategory->eloquent->create([ 'name' => 'Work' ]);
     $mContactCategory->eloquent->create([ 'name' => 'Home' ]);
     $mContactCategory->eloquent->create([ 'name' => 'Other' ]);
-
-    $mTag->eloquent->create([ 'name' => "Important", 'color' => '#008f7a' ]);
-    $mTag->eloquent->create([ 'name' => "Partner", 'color' => '#845ec2' ]);
-    $mTag->eloquent->create([ 'name' => "Needs review", 'color' => '#2c73d2' ]);
 
     $countries = [
       [1, 'Aruba', 'ABW'],

--- a/src/cli/Agent/Project/GenerateDemoData.php
+++ b/src/cli/Agent/Project/GenerateDemoData.php
@@ -126,22 +126,6 @@ class GenerateDemoData extends \HubletoMain\Cli\Agent\Command
     ]);
   }
 
-  public function generateTags(): void
-  {
-
-    $mTag = new \HubletoApp\Community\Settings\Models\Tag($this->main);
-
-    $mTag->record->create([
-      'name' => "Category 1",
-    ]);
-    $mTag->record->create([
-      'name' => "Category 2",
-    ]);
-    $mTag->record->create([
-      'name' => "Category 3",
-    ]);
-  }
-
   public function generateCustomers(
     \HubletoApp\Community\Customers\Models\Customer $mCustomer,
     \HubletoApp\Community\Customers\Models\CustomerTag $mCustomerTag,
@@ -472,7 +456,7 @@ class GenerateDemoData extends \HubletoMain\Cli\Agent\Command
       for ($i = 0; $i < $tagCount; $i++) {
         $mPersonTag->record->create([
           "id_person" => $idPerson,
-          "id_tag" => rand(1, 3)
+          "id_tag" => rand(1, 6)
         ]);
       }
     }


### PR DESCRIPTION
Based on #66:

- created new `Tag` models for every model/app that used tags
- removed the base `Tag` model in the Setting App because it is no longer needed
- added tags to the `Contact Person` tables
- added setting buttons for all the `Tag` models
- some fixes to latest changes
- fixed the activity selector form in #68 