### PR TITLE
deal/lead prefix, default deal result

### DIFF
--- a/apps/community/Deals/Components/FormDeal.tsx
+++ b/apps/community/Deals/Components/FormDeal.tsx
@@ -207,7 +207,7 @@ export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealSt
                 <div className='card mt-2' style={{gridArea: 'info'}}>
                   <div className='card-body flex flex-row gap-2'>
                     <div className='grow'>
-                      {this.inputWrapper('identifier', {readonly: R.is_archived})}
+                      {showAdditional ? this.inputWrapper('identifier', {readonly: R.is_archived}) : <></>}
                       {this.inputWrapper('title', {readonly: R.is_archived})}
                       <FormInput title={"Customer"} required={true}>
                         <Lookup {...this.getInputProps("id_customer")}

--- a/apps/community/Deals/Controllers/Settings.php
+++ b/apps/community/Deals/Controllers/Settings.php
@@ -32,6 +32,10 @@ class Settings extends \HubletoMain\Core\Controllers\Controller
       $this->hubletoApp->setConfigAsString('calendarColor', $calendarColor);
       $this->hubletoApp->saveConfig('calendarColor', $calendarColor);
 
+      $dealPrefix = $this->main->urlParamAsString('dealPrefix');
+      $this->hubletoApp->setConfigAsString('dealPrefix', $dealPrefix);
+      $this->hubletoApp->saveConfig('dealPrefix', $dealPrefix);
+
       $this->viewParams['settingsSaved'] = true;
     }
 

--- a/apps/community/Deals/Views/Settings.twig
+++ b/apps/community/Deals/Views/Settings.twig
@@ -62,6 +62,17 @@
             />
           </td>
         </tr>
+        <tr>
+          <td>Deals Prefix</td>
+          <td>
+            <input
+              type="text" name="dealPrefix"
+              class="adios component input"
+              value="{{ viewParams.app.configAsString('dealPrefix') }}"
+              onchange="saveSettings();"
+            />
+          </td>
+        </tr>
       </tbody>
     </table>
   </form>

--- a/apps/community/Leads/Components/FormLead.tsx
+++ b/apps/community/Leads/Components/FormLead.tsx
@@ -213,7 +213,7 @@ export default class FormLead<P, S> extends HubletoForm<FormLeadProps,FormLeadSt
                 <div className='flex-2 card'>
                   <div className='card-body flex flex-row gap-2'>
                     <div className='grow'>
-                      {this.inputWrapper('identifier', {readonly: R.is_archived})}
+                      {showAdditional ? this.inputWrapper('identifier', {readonly: R.is_archived}) : <></>}
                       {this.inputWrapper('title', {readonly: R.is_archived})}
                       <FormInput title={"Customer"}>
                         <Lookup {...this.getInputProps('id-customer')}

--- a/apps/community/Leads/Controllers/Settings.php
+++ b/apps/community/Leads/Controllers/Settings.php
@@ -28,6 +28,10 @@ class Settings extends \HubletoMain\Core\Controllers\Controller
       $this->hubletoApp->setConfigAsString('calendarColor', $calendarColor);
       $this->hubletoApp->saveConfig('calendarColor', $calendarColor);
 
+      $leadPrefix = $this->main->urlParamAsString('leadPrefix');
+      $this->hubletoApp->setConfigAsString('leadPrefix', $leadPrefix);
+      $this->hubletoApp->saveConfig('leadPrefix', $leadPrefix);
+
       $this->viewParams['settingsSaved'] = true;
     }
 

--- a/apps/community/Leads/Models/Lead.php
+++ b/apps/community/Leads/Models/Lead.php
@@ -202,6 +202,10 @@ class Lead extends \HubletoMain\Core\Models\Model
       "description" => "Lead created"
     ]);
 
+    $newLead = $savedRecord;
+    $newLead["identifier"] = $this->main->apps->community('Leads')->configAsString('leadPrefix') . str_pad($savedRecord["id"], 6, 0, STR_PAD_LEFT);
+    $this->record->recordUpdate($newLead);
+
     return parent::onAfterCreate($originalRecord, $savedRecord);
   }
 

--- a/apps/community/Leads/Views/Settings.twig
+++ b/apps/community/Leads/Views/Settings.twig
@@ -55,6 +55,17 @@
             />
           </td>
         </tr>
+        <tr>
+          <td>Lead Prefix</td>
+          <td>
+            <input
+              type="text" name="leadPrefix"
+              class="adios component input"
+              value="{{ viewParams.app.configAsString('leadPrefix') }}"
+              onchange="saveSettings();"
+            />
+          </td>
+        </tr>
       </tbody>
     </table>
   </form>

--- a/apps/community/Settings/Models/PipelineStep.php
+++ b/apps/community/Settings/Models/PipelineStep.php
@@ -6,6 +6,7 @@ use ADIOS\Core\Db\Column\Color;
 use ADIOS\Core\Db\Column\Integer;
 use ADIOS\Core\Db\Column\Lookup;
 use ADIOS\Core\Db\Column\Varchar;
+use HubletoApp\Community\Deals\Models\Deal;
 
 class PipelineStep extends \HubletoMain\Core\Models\Model
 {
@@ -25,7 +26,7 @@ class PipelineStep extends \HubletoMain\Core\Models\Model
       'color' => (new Color($this, $this->translate('Color')))->setRequired(),
       'id_pipeline' => (new Lookup($this, $this->translate("Pipeline"), Pipeline::class, 'CASCADE'))->setRequired(),
       'set_result' => (new Integer($this, $this->translate('Set result of a deal to')))->setRequired()
-        ->setEnumValues([1 => "Lost", 2 => "Won", 3 => "Pending"])
+        ->setEnumValues([Deal::RESULT_LOST => "Lost", Deal::RESULT_WON => "Won", Deal::RESULT_PENDING => "Pending"])
     ]);
   }
 


### PR DESCRIPTION
- added automatic creation of identifiers for deals/leads created based on the IDs of the deal/lead
- added an input field into the app settings of leads/deals that determines the prefix of the identifiers of the deals/leads
  - the prefix can be set by the user, the sufix is zeros before the ID of the lead/deal
- added a default deal result when creating a deal
- added constants for enumValues of various models