### PR TITLE
relation document file deletion

### DIFF
--- a/apps/community/Contacts/Models/Contact.php
+++ b/apps/community/Contacts/Models/Contact.php
@@ -20,7 +20,7 @@ class Contact extends \HubletoMain\Core\Models\Model
   {
     return array_merge(parent::describeColumns(), [
       'id_person' => (new Lookup($this, $this->translate('Person'), Person::class, "CASCADE"))->setRequired(),
-      'id_contact_category' => (new Lookup($this, $this->translate('Contact Category'), ContactCategory::class)),
+      'id_contact_category' => (new Lookup($this, $this->translate('Contact Category'), ContactCategory::class))->setRequired(),
       'type' => (new Varchar($this, $this->translate('Type')))
         ->setEnumValues(['email' => $this->translate('Email'), 'number' => $this->translate('Phone Number'), 'other' => $this->translate('Other')])
         ->setRequired()

--- a/apps/community/Customers/Components/FormCustomer.tsx
+++ b/apps/community/Customers/Components/FormCustomer.tsx
@@ -17,6 +17,7 @@ import FormPerson, {FormPersonProps, FormPersonState} from "../../Contacts/Compo
 import Calendar from '../../Calendar/Components/Calendar'
 import Hyperlink from "adios/Inputs/Hyperlink";
 import request from "adios/Request";
+import { FormProps, FormState } from "adios/Form";
 
 export interface FormCustomerProps extends HubletoFormProps {
   highlightIdActivity: number,
@@ -40,6 +41,7 @@ interface FormCustomerState extends HubletoFormState {
   activityCalendarTimeClicked: string,
   activityCalendarDateClicked: string,
   tableContactsDescription?: any,
+  tablesKey: number,
 }
 
 export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, FormCustomerState> {
@@ -67,7 +69,12 @@ export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, F
       showIdActivity: 0,
       activityCalendarTimeClicked: '',
       activityCalendarDateClicked: '',
+      tablesKey: 0,
     }
+  }
+
+  componentDidUpdate(prevProps: FormProps, prevState: FormState): void {
+    if (prevState.isInlineEditing != this.state.isInlineEditing) this.setState({tablesKey: Math.random()} as FormCustomerState)
   }
 
   getStateFromProps(props: FormCustomerProps) {
@@ -572,7 +579,8 @@ export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, F
                 <span className="text">Add document</span>
               </a>
               <TableCustomerDocuments
-                uid={this.props.uid + "_table_deals"}
+                key={this.state.tablesKey + "_table_documents"}
+                uid={this.props.uid + "_table_documents"}
                 data={{ data: R.DOCUMENTS }}
                 descriptionSource="props"
                 customEndpointParams={{idCustomer: R.id}}
@@ -604,6 +612,10 @@ export default class FormCustomer<P, S> extends HubletoForm<FormCustomerProps, F
                 }}
                 onRowClick={(table: TableCustomerDocuments, row: any) => {
                   this.setState({showIdDocument: row.id_document} as FormCustomerState);
+                }}
+                onDeleteSelectionChange={(table) => {
+                  this.updateRecord({ DOCUMENTS: table.state.data?.data ?? []});
+                  this.setState({tablesKey: Math.random()} as FormCustomerState)
                 }}
               />
               {this.state.showIdDocument != 0 ?

--- a/apps/community/Customers/Models/CustomerDocument.php
+++ b/apps/community/Customers/Models/CustomerDocument.php
@@ -52,4 +52,13 @@ class CustomerDocument extends \HubletoMain\Core\Models\Model
 
     return $description;
   }
+
+  public function onBeforeDelete(int $id): int
+  {
+    $idDocument = (int) $this->record->find($id)->toArray()["id_document"];
+    (new Document($this->main))->onBeforeDelete($idDocument);
+    (new Document($this->main))->record->where("id", $idDocument)->delete();
+
+    return $id;
+  }
 }

--- a/apps/community/Deals/Components/FormDeal.tsx
+++ b/apps/community/Deals/Components/FormDeal.tsx
@@ -583,6 +583,7 @@ export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealSt
                 </a>
               : null}
               <TableDealDocuments
+                key={this.state.tablesKey + "_table_deal_document"}
                 uid={this.props.uid + "_table_deal_documents"}
                 data={{ data: R.DOCUMENTS }}
                 customEndpointParams={{idDeal: R.id}}
@@ -615,6 +616,10 @@ export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealSt
                 readonly={R.is_archived == true ? false : !this.state.isInlineEditing}
                 onRowClick={(table: TableDealDocuments, row: any) => {
                   this.setState({showIdDocument: row.id_document} as FormDealState);
+                }}
+                onDeleteSelectionChange={(table) => {
+                  this.updateRecord({ DOCUMENTS: table.state.data?.data ?? []});
+                  this.setState({tablesKey: Math.random()} as FormDealState)
                 }}
               />
               {this.state.showIdDocument != 0 ?

--- a/apps/community/Deals/Models/DealDocument.php
+++ b/apps/community/Deals/Models/DealDocument.php
@@ -51,4 +51,13 @@ class DealDocument extends \HubletoMain\Core\Models\Model
 
     return $description;
   }
+
+  public function onBeforeDelete(int $id): int
+  {
+    $idDocument = (int) $this->record->find($id)->toArray()["id_document"];
+    (new Document($this->main))->onBeforeDelete($idDocument);
+    (new Document($this->main))->record->where("id", $idDocument)->delete();
+
+    return $id;
+  }
 }

--- a/apps/community/Leads/Components/FormLead.tsx
+++ b/apps/community/Leads/Components/FormLead.tsx
@@ -14,6 +14,7 @@ import FormDocument, { FormDocumentProps, FormDocumentState } from '../../Docume
 import FormActivity, { FormActivityProps, FormActivityState } from './FormActivity';
 import Hyperlink from 'adios/Inputs/Hyperlink';
 import { FormProps, FormState } from 'adios/Form';
+import { table } from 'console';
 
 export interface FormLeadProps extends HubletoFormProps {
   newEntryId?: number,
@@ -544,6 +545,7 @@ export default class FormLead<P, S> extends HubletoForm<FormLeadProps,FormLeadSt
                 </a>
               : null}
               <TableLeadDocuments
+                key={this.state.tablesKey + "_table_lead_document"}
                 uid={this.props.uid + "_table_lead_document"}
                 data={{ data: R.DOCUMENTS }}
                 descriptionSource="both"
@@ -576,6 +578,10 @@ export default class FormLead<P, S> extends HubletoForm<FormLeadProps,FormLeadSt
                 readonly={R.is_archived == true ? false : !this.state.isInlineEditing}
                 onRowClick={(table: TableLeadDocuments, row: any) => {
                   this.setState({showIdDocument: row.id_document} as FormLeadState);
+                }}
+                onDeleteSelectionChange={(table) => {
+                  this.updateRecord({ DOCUMENTS: table.state.data?.data ?? []});
+                  this.setState({tablesKey: Math.random()} as FormLeadState)
                 }}
               />
               {this.state.showIdDocument != 0 ?

--- a/apps/community/Leads/Models/LeadDocument.php
+++ b/apps/community/Leads/Models/LeadDocument.php
@@ -51,4 +51,13 @@ class LeadDocument extends \HubletoMain\Core\Models\Model
 
     return $description;
   }
+
+  public function onBeforeDelete(int $id): int
+  {
+    $idDocument = (int) $this->record->find($id)->toArray()["id_document"];
+    (new Document($this->main))->onBeforeDelete($idDocument);
+    (new Document($this->main))->record->where("id", $idDocument)->delete();
+
+    return $id;
+  }
 }


### PR DESCRIPTION
- added `onBeforeDelete` methods to models which use the `Document` model hubleto/main#64
  - this method deletes the file of the document through the relation model
  - added the "key fix" #146  to the relevant inline document table components 
- added a requirement for `Contact Category` in the `Contact` model