### PR TITLE
Form deal and lead changes

### DIFF
--- a/apps/community/Deals/Components/FormDeal.tsx
+++ b/apps/community/Deals/Components/FormDeal.tsx
@@ -266,6 +266,8 @@ export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealSt
                       {this.inputWrapper('id_user', {readonly: R.is_archived})}
                       {this.inputWrapper('date_expected_close', {readonly: R.is_archived})}
                       {this.inputWrapper('source_channel', {readonly: R.is_archived})}
+                      {this.inputWrapper('is_new_customer', {readonly: R.is_archived})}
+                      {this.inputWrapper('business_type', {uiStyle: 'buttons', readonly: R.is_archived})}
                       <FormInput title='Tags'>
                         <InputTags2 {...this.getInputProps('tags')}
                           value={this.state.record.TAGS}
@@ -283,9 +285,9 @@ export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealSt
                     </div>
                     <div className='border-l border-gray-200'></div>
                     <div className='grow'>
-                      {this.inputWrapper("deal_result", {uiStyle: 'buttons'})}
-                      {this.inputWrapper('is_new_customer')}
-                      {this.inputWrapper('business_type', {uiStyle: 'buttons'})}
+                      {this.inputWrapper("deal_result", {uiStyle: 'buttons', readonly: R.is_archived, onChange: () => {this.updateRecord({lost_reason: null})}})}
+                      {this.state.record.deal_result == 3 ? this.inputWrapper('lost_reason', {readonly: R.is_archived}): null}
+                      {showAdditional ? this.inputWrapper('date_result_update') : null}
                       {showAdditional ? this.inputWrapper('date_created') : null}
                       {showAdditional ? this.inputWrapper('is_archived') : null}
                     </div>
@@ -316,7 +318,7 @@ export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealSt
                               return (
                                 <>
                                   <button
-                                    onClick={R.is_archived ? null : ()=>{
+                                    onClick={R.is_archived ? null : () => {
                                       if (this.state.isInlineEditing == false) this.setState({isInlineEditing: true});
                                       R.id_pipeline_step = s.id;
                                       R.deal_result = s.set_result;

--- a/apps/community/Leads/Components/FormLead.tsx
+++ b/apps/community/Leads/Components/FormLead.tsx
@@ -260,7 +260,8 @@ export default class FormLead<P, S> extends HubletoForm<FormLeadProps,FormLeadSt
                         })}
                         {this.inputWrapper('id_currency')}
                       </div>
-                      {showAdditional ? this.inputWrapper('status', {readonly: R.is_archived}) : null}
+                      {this.inputWrapper('status', {readonly: R.is_archived, onChange: () => {this.updateRecord({lost_reason: null})}})}
+                      {this.state.record.status == 4 ? this.inputWrapper('lost_reason', {readonly: R.is_archived}): null}
                       {showAdditional ?
                         <div className='w-full mt-2'>
                           {R.DEAL != null ?

--- a/apps/community/Settings/Loader.php
+++ b/apps/community/Settings/Loader.php
@@ -2,6 +2,7 @@
 
 namespace HubletoApp\Community\Settings;
 
+use HubletoApp\Community\Deals\Models\Deal;
 use HubletoApp\Community\Settings\Models\Permission;
 
 class Loader extends \HubletoMain\Core\App
@@ -91,17 +92,17 @@ class Loader extends \HubletoMain\Core\App
       $mCurrency->record->recordCreate([ 'name' => 'Koruny', 'code' => 'CZK' ]);
 
       $mPipeline->record->recordCreate([ "name" => "New customer" ]);
-      $mPipelineStep->record->recordCreate([ 'name' => 'New', 'order' => 1, 'color' => '#4080A0', 'id_pipeline' => 1 , "set_result" => 3]);
-      $mPipelineStep->record->recordCreate([ 'name' => 'In Progress', 'order' => 2, 'color' => '#A04020', 'id_pipeline' => 1, "set_result" => 3]);
-      $mPipelineStep->record->recordCreate([ 'name' => 'Closed', 'order' => 3, 'color' => '#006060', 'id_pipeline' => 1, "set_result" => 2 ]);
-      $mPipelineStep->record->recordCreate([ 'name' => 'Lost', 'order' => 4, 'color' => '#f50c0c', 'id_pipeline' => 1, "set_result" => 1 ]);
+      $mPipelineStep->record->recordCreate([ 'name' => 'New', 'order' => 1, 'color' => '#4080A0', 'id_pipeline' => 1 , "set_result" => Deal::RESULT_PENDING]);
+      $mPipelineStep->record->recordCreate([ 'name' => 'In Progress', 'order' => 2, 'color' => '#A04020', 'id_pipeline' => 1, "set_result" => Deal::RESULT_PENDING]);
+      $mPipelineStep->record->recordCreate([ 'name' => 'Closed', 'order' => 3, 'color' => '#006060', 'id_pipeline' => 1, "set_result" => Deal::RESULT_WON ]);
+      $mPipelineStep->record->recordCreate([ 'name' => 'Lost', 'order' => 4, 'color' => '#f50c0c', 'id_pipeline' => 1, "set_result" => Deal::RESULT_LOST ]);
 
       $mPipeline->record->recordCreate([ "name" => "Existing customer" ]);
-      $mPipelineStep->record->recordCreate([ 'name' => 'Start', 'order' => 1, 'color' => '#405060', 'id_pipeline' => 2, "set_result" => 3 ]);
-      $mPipelineStep->record->recordCreate([ 'name' => 'Client Contacted', 'order' => 2, 'color' => '#800000', 'id_pipeline' => 2, "set_result" => 3 ]);
-      $mPipelineStep->record->recordCreate([ 'name' => 'In Progress', 'order' => 3, 'color' => '#808000', 'id_pipeline' => 2, "set_result" => 3 ]);
-      $mPipelineStep->record->recordCreate([ 'name' => 'Ended', 'order' => 4, 'color' => '#002080', 'id_pipeline' => 2, "set_result" => 2 ]);
-      $mPipelineStep->record->recordCreate([ 'name' => 'Lost', 'order' => 5, 'color' => '#f50c0c', 'id_pipeline' => 2, "set_result" => 1 ]);
+      $mPipelineStep->record->recordCreate([ 'name' => 'Start', 'order' => 1, 'color' => '#405060', 'id_pipeline' => 2, "set_result" => Deal::RESULT_PENDING ]);
+      $mPipelineStep->record->recordCreate([ 'name' => 'Client Contacted', 'order' => 2, 'color' => '#800000', 'id_pipeline' => 2, "set_result" => Deal::RESULT_PENDING ]);
+      $mPipelineStep->record->recordCreate([ 'name' => 'In Progress', 'order' => 3, 'color' => '#808000', 'id_pipeline' => 2, "set_result" => Deal::RESULT_PENDING ]);
+      $mPipelineStep->record->recordCreate([ 'name' => 'Ended', 'order' => 4, 'color' => '#002080', 'id_pipeline' => 2, "set_result" => Deal::RESULT_WON ]);
+      $mPipelineStep->record->recordCreate([ 'name' => 'Lost', 'order' => 5, 'color' => '#f50c0c', 'id_pipeline' => 2, "set_result" => Deal::RESULT_LOST ]);
 
       $mActivityTypes->record->recordCreate([ 'name' => 'Meeting', 'color' => '#607d8b', 'calendar_visibility' => true ]);
       $mActivityTypes->record->recordCreate([ 'name' => 'Bussiness Trip', 'color' => '#673ab7', 'calendar_visibility' => true ]);

--- a/src/cli/Agent/Project/GenerateDemoData.php
+++ b/src/cli/Agent/Project/GenerateDemoData.php
@@ -622,7 +622,7 @@ class GenerateDemoData extends \HubletoMain\Cli\Agent\Command
       if (rand(1, 3) != 1) continue; // negenerujem deal pre vsetky leads
 
       $pipeline = rand(1,2);
-      $result = rand(1,3);
+      $result = rand($mDeal::RESULT_PENDING,$mDeal::RESULT_LOST);
       if ($pipeline === 1) $pipelineStep = rand(1,3);
       else $pipelineStep = rand(4,7);
 


### PR DESCRIPTION
- added a Lost Reason to Deal and Lead forms #114, #121
  - shows only if the deal result or lead status is set to lost
- refactored the constant values of the deal result and the lead status
- in lead and deals, fixed the price changing to zero, if there were no products present (this could have caused an issue, if the price was manually set)
- added "Date of last result change" value to the deal form