### PR TITLE
Order and search queries for virtual columns

### DIFF
--- a/apps/community/Contacts/Models/RecordManagers/Person.php
+++ b/apps/community/Contacts/Models/RecordManagers/Person.php
@@ -37,4 +37,97 @@ class Person extends \HubletoMain\Core\RecordManager
 
     return $query;
   }
+
+  public function addOrderByToQuery(mixed $query, array $orderBy): mixed
+  {
+    if (isset($orderBy['field']) && $orderBy['field'] == 'tags') {
+      if (empty($this->joinManager["tags"])) {
+        $this->joinManager["tags"]["order"] = true;
+        $query
+          ->addSelect("person_tags.name")
+          ->join('cross_person_tags', 'cross_person_tags.id_person', '=', 'persons.id')
+          ->join('person_tags', 'cross_person_tags.id_tag', '=', 'person_tags.id')
+        ;
+      }
+      $query->orderBy('person_tags.name', $orderBy['direction']);
+
+      return $query;
+    } else {
+      return parent::addOrderByToQuery($query, $orderBy);
+    }
+  }
+
+  public function addFulltextSearchToQuery(mixed $query, string $fulltextSearch): mixed
+  {
+    if (!empty($fulltextSearch)) {
+      $query = parent::addFulltextSearchToQuery($query, $fulltextSearch);
+
+      if (empty($this->joinManager["tags"])) {
+        $this->joinManager["tags"]["fullText"] = true;
+        $query
+          ->addSelect("person_tags.name as personTag")
+          ->join('cross_person_tags', 'cross_person_tags.id_person', '=', 'persons.id')
+          ->join('person_tags', 'cross_person_tags.id_tag', '=', 'person_tags.id')
+        ;
+      }
+      $query->orHaving('personTag', 'like', "%{$fulltextSearch}%");
+
+      if (empty($this->joinManager["virt_contact"])) {
+        $this->joinManager["virt_contact"]["fullText"] = true;
+        $query
+          ->addSelect("contacts.value")
+          ->join('contacts', 'contacts.id_person', '=', 'persons.id')
+        ;
+      }
+      $query->orHaving('contacts.value', 'like', "%{$fulltextSearch}%");
+
+    }
+    return $query;
+  }
+
+  public function addColumnSearchToQuery(mixed $query, array $columnSearch): mixed
+  {
+    $query = parent::addColumnSearchToQuery($query, $columnSearch);
+
+    if (!empty($columnSearch) && !empty($columnSearch['tags'])) {
+      if (empty($this->joinManager["tags"])) {
+        $this->joinManager["tags"]["column"] = true;
+        $query
+          ->addSelect("person_tags.name as personTag")
+          ->join('cross_person_tags', 'cross_person_tags.id_person', '=', 'persons.id')
+          ->join('person_tags', 'cross_person_tags.id_tag', '=', 'person_tags.id')
+        ;
+      }
+      $query->having('personTag', 'like', "%{$columnSearch['tags']}%");
+    }
+
+    if (!empty($columnSearch) && !empty($columnSearch['virt_email'])) {
+      if (empty($this->joinManager["virt_contact"])) {
+        $this->joinManager["virt_contact"]["email"] = true;
+        $query
+          ->addSelect("contacts.value")
+          ->join('contacts', 'contacts.id_person', '=', 'persons.id')
+        ;
+      }
+      $query
+        ->where("contacts.type", "email")
+        ->orHaving('contacts.value', 'like', "%{$columnSearch['virt_email']}%")
+      ;
+    }
+
+    if (!empty($columnSearch) && !empty($columnSearch['virt_number'])) {
+      if (empty($this->joinManager["virt_contact"])) {
+        $this->joinManager["virt_contact"]["number"] = true;
+        $query
+          ->addSelect("contacts.value")
+          ->join('contacts', 'contacts.id_person', '=', 'persons.id')
+        ;
+      }
+      $query
+        ->where("contacts.type", "number")
+        ->orHaving('contacts.value', 'like', "%{$columnSearch['virt_number']}%")
+      ;
+    }
+    return $query;
+  }
 }

--- a/apps/community/Deals/Models/RecordManagers/Deal.php
+++ b/apps/community/Deals/Models/RecordManagers/Deal.php
@@ -109,4 +109,60 @@ class Deal extends \HubletoMain\Core\RecordManager
     return $query;
   }
 
+  public function addOrderByToQuery(mixed $query, array $orderBy): mixed
+  {
+    if (isset($orderBy['field']) && $orderBy['field'] == 'tags') {
+      if (empty($this->joinManager["tags"])) {
+        $this->joinManager["tags"]["order"] = true;
+        $query
+          ->addSelect("deal_tags.name")
+          ->join('cross_deal_tags', 'cross_deal_tags.id_deal', '=', 'deals.id')
+          ->join('deal_tags', 'cross_deal_tags.id_tag', '=', 'deal_tags.id')
+        ;
+      }
+      $query->orderBy('deal_tags.name', $orderBy['direction']);
+
+      return $query;
+    } else {
+      return parent::addOrderByToQuery($query, $orderBy);
+    }
+  }
+
+  public function addFulltextSearchToQuery(mixed $query, string $fulltextSearch): mixed
+  {
+    if (!empty($fulltextSearch)) {
+      $query = parent::addFulltextSearchToQuery($query, $fulltextSearch);
+
+      if (empty($this->joinManager["tags"])) {
+        $this->joinManager["tags"]["fullText"] = true;
+        $query
+          ->addSelect("deal_tags.name")
+          ->join('cross_deal_tags', 'cross_deal_tags.id_deal', '=', 'deals.id')
+          ->join('deal_tags', 'cross_deal_tags.id_tag', '=', 'deal_tags.id')
+        ;
+      }
+      $query->orHaving('deal_tags.name', 'like', "%{$fulltextSearch}%");
+
+    }
+    return $query;
+  }
+
+  public function addColumnSearchToQuery(mixed $query, array $columnSearch): mixed
+  {
+    $query = parent::addColumnSearchToQuery($query, $columnSearch);
+
+    if (!empty($columnSearch) && !empty($columnSearch['tags'])) {
+      if (empty($this->joinManager["tags"])) {
+        $this->joinManager["tags"]["column"] = true;
+        $query
+          ->addSelect("deal_tags.name")
+          ->join('cross_deal_tags', 'cross_deal_tags.id_deal', '=', 'deals.id')
+          ->join('deal_tags', 'cross_deal_tags.id_tag', '=', 'deal_tags.id')
+        ;
+      }
+      $query->having('deal_tags.name', 'like', "%{$columnSearch['tags']}%");
+    }
+    return $query;
+  }
+
 }

--- a/src/core/RecordManager.php
+++ b/src/core/RecordManager.php
@@ -2,4 +2,6 @@
 
 namespace HubletoMain\Core;
 
-class RecordManager extends \ADIOS\Core\EloquentRecordManager { }
+class RecordManager extends \ADIOS\Core\EloquentRecordManager {
+  public $joinManager = [];
+}


### PR DESCRIPTION
Added `order by` and search queries for various virtual columns in various tables, mainly for the Tag columns
*This does not resolve the issue with inline editable tables*

related to: #105, #104 