### PR TITLE
lost reason, result change step, fixes

### DIFF
--- a/apps/community/Deals/Components/FormDeal.tsx
+++ b/apps/community/Deals/Components/FormDeal.tsx
@@ -151,6 +151,20 @@ export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealSt
     return (probability / 100) * price;
   }
 
+  changePipelineStepFromResult() {
+    if (this.state.record.PIPELINE.PIPELINE_STEPS.length > 0) {
+      this.state.record.PIPELINE.PIPELINE_STEPS.some(step => {
+        if (step.set_result == this.state.record.deal_result) {
+          let R = this.state.record;
+          R.id_pipeline_step = step.id;
+          R.PIPELINE_STEP = step;
+          this.setState({record: R});
+          return true;
+        } else return false;
+      })
+    }
+  }
+
   onCreateActivityCallback() {
     this.loadRecord();
   }
@@ -289,7 +303,16 @@ export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealSt
                     </div>
                     <div className='border-l border-gray-200'></div>
                     <div className='grow'>
-                      {this.inputWrapper("deal_result", {uiStyle: 'buttons', readonly: R.is_archived, onChange: () => {this.updateRecord({lost_reason: null})}})}
+                      {this.inputWrapper("deal_result",
+                        {
+                          uiStyle: 'buttons',
+                          readonly: R.is_archived,
+                          onChange: () => {
+                            this.updateRecord({lost_reason: null});
+                            this.changePipelineStepFromResult();
+                          }
+                        }
+                      )}
                       {this.state.record.deal_result == 3 ? this.inputWrapper('lost_reason', {readonly: R.is_archived}): null}
                       {showAdditional ? this.inputWrapper('date_result_update') : null}
                       {showAdditional ? this.inputWrapper('date_created') : null}
@@ -313,11 +336,13 @@ export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealSt
                               }}
                             ></Lookup>
                           </FormInput>
-                          <div className='self-center'>
-                            <p>Price based on the probability of current step ({R.PIPELINE_STEP.probability} %):
-                              <strong> {this.calculateProbabilityPrice(R.PIPELINE_STEP.probability, R.price)} {R.CURRENCY.code}</strong>
-                            </p>
-                          </div>
+                          {R.PIPELINE_STEP && R.PIPELINE_STEP.probability ?
+                            <div className='self-center'>
+                              <p>Price based on the probability of current step ({R.PIPELINE_STEP.probability} %):
+                                <strong> {this.calculateProbabilityPrice(R.PIPELINE_STEP.probability, R.price)} {R.CURRENCY.code}</strong>
+                              </p>
+                            </div>
+                          : <></>}
                         </div>
                         <div className='flex flex-row gap-2 mt-2 flex-wrap justify-center'>
                           {R.PIPELINE != null &&

--- a/apps/community/Deals/Controllers/LostReasons.php
+++ b/apps/community/Deals/Controllers/LostReasons.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace HubletoApp\Community\Deals\Controllers;
+
+class LostReasons extends \HubletoMain\Core\Controllers\Controller {
+
+  public function getBreadcrumbs(): array
+  {
+    return array_merge(parent::getBreadcrumbs(), [
+      [ 'url' => 'settings', 'content' => $this->translate('Settings') ],
+      [ 'url' => '', 'content' => $this->translate('Deal Lost Reasons') ],
+    ]);
+  }
+
+  public function prepareView(): void
+  {
+    parent::prepareView();
+    $this->setView('@HubletoApp:Community:Deals/LostReasons.twig');
+  }
+
+}

--- a/apps/community/Deals/Loader.php
+++ b/apps/community/Deals/Loader.php
@@ -19,6 +19,7 @@ class Loader extends \HubletoMain\Core\App
       '/^deals\/archive\/?$/' => Controllers\DealsArchive::class,
       '/^deals\/change-pipeline\/?$/' => Controllers\Api\ChangePipeline::class,
       '/^settings\/deal-tags\/?$/' => Controllers\Tags::class,
+      '/^settings\/deal-lost-reasons\/?$/' => Controllers\LostReasons::class,
       '/^deals\/boards\/most-valuable-deals\/?$/' => Controllers\Boards\MostValuableDeals::class,
       '/^deals\/boards\/deal-value-by-result\/?$/' => Controllers\Boards\DealValueByResult::class,
     ]);
@@ -27,6 +28,11 @@ class Loader extends \HubletoMain\Core\App
       'title' => $this->translate('Deal Tags'),
       'icon' => 'fas fa-tags',
       'url' => 'settings/deal-tags',
+    ]);
+    $this->main->addSetting($this, [
+      'title' => $this->translate('Deal Lost Reasons'),
+      'icon' => 'fas fa-tags',
+      'url' => 'settings/deal-lost-reasons',
     ]);
 
     $calendarManager = $this->main->apps->community('Calendar')->calendarManager;
@@ -74,7 +80,9 @@ class Loader extends \HubletoMain\Core\App
       $mDealProduct = new \HubletoApp\Community\Deals\Models\DealProduct($this->main);
       $mDealActivity = new \HubletoApp\Community\Deals\Models\DealActivity($this->main);
       $mDealDocument = new \HubletoApp\Community\Deals\Models\DealDocument($this->main);
+      $mLostReasons = new \HubletoApp\Community\Deals\Models\LostReason($this->main);
 
+      $mLostReasons->dropTableIfExists()->install();
       $mDeal->dropTableIfExists()->install();
       $mDealHistory->dropTableIfExists()->install();
       $mDealTag->dropTableIfExists()->install();
@@ -88,6 +96,11 @@ class Loader extends \HubletoMain\Core\App
       $mDealTag->record->recordCreate([ 'name' => "Extenstion", 'color' => '#033dfc' ]);
       $mDealTag->record->recordCreate([ 'name' => "New Customer", 'color' => '#fcdb03' ]);
       $mDealTag->record->recordCreate([ 'name' => "Existing Customer", 'color' => '#5203fc' ]);
+
+      $mLostReasons->record->recordCreate(["reason" => "Price"]);
+      $mLostReasons->record->recordCreate(["reason" => "Solution"]);
+      $mLostReasons->record->recordCreate(["reason" => "Demand canceled by customer"]);
+      $mLostReasons->record->recordCreate(["reason" => "Other"]);
     }
   }
 

--- a/apps/community/Deals/Models/Deal.php
+++ b/apps/community/Deals/Models/Deal.php
@@ -81,7 +81,7 @@ class Deal extends \HubletoMain\Core\Models\Model
       'is_archived' => (new Boolean($this, $this->translate('Archived'))),
       'deal_result' => (new Integer($this, $this->translate('Deal Result')))
         ->setEnumValues([$this::RESULT_PENDING => "Pending", $this::RESULT_WON => "Won", $this::RESULT_LOST => "Lost"])->setDefaultValue(3),
-      'lost_reason' => new Text($this, "Reason for Lost"),
+      'lost_reason' => (new Lookup($this, $this->translate("Reason for Lost"), LostReason::class)),
       'date_result_update' => (new DateTime($this, $this->translate('Date of result update')))->setReadonly(),
       'is_new_customer' => new Boolean($this, $this->translate('New Customer')),
       'business_type' => (new Integer($this, $this->translate('Business type')))->setEnumValues(

--- a/apps/community/Deals/Models/LostReason.php
+++ b/apps/community/Deals/Models/LostReason.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace HubletoApp\Community\Deals\Models;
+
+use ADIOS\Core\Db\Column\Varchar;
+
+class LostReason extends \HubletoMain\Core\Models\Model
+{
+  public string $table = 'deal_lost_reasons';
+  public string $recordManagerClass = RecordManagers\LostReason::class;
+  public ?string $lookupSqlValue = '{%TABLE%}.reason';
+
+  public function describeColumns(): array
+  {
+    return array_merge(parent::describeColumns(), [
+      'reason' => (new Varchar($this, $this->translate('Lost Reason')))->setRequired(),
+    ]);
+  }
+
+  public function describeTable(): \ADIOS\Core\Description\Table
+  {
+    $description = parent::describeTable();
+    $description->ui['title'] = 'Deal Lost Reasons';
+    $description->ui['addButtonText'] = 'Add Reason';
+    return $description;
+  }
+
+}

--- a/apps/community/Deals/Models/RecordManagers/LostReason.php
+++ b/apps/community/Deals/Models/RecordManagers/LostReason.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace HubletoApp\Community\Deals\Models\RecordManagers;
+
+class LostReason extends \HubletoMain\Core\RecordManager
+{
+  public $table = 'deal_lost_reasons';
+
+}

--- a/apps/community/Deals/Views/LostReasons.twig
+++ b/apps/community/Deals/Views/LostReasons.twig
@@ -1,0 +1,1 @@
+<app-table string:model="HubletoApp/Community/Deals/Models/LostReason"></app-table>

--- a/apps/community/Leads/Controllers/LostReasons.php
+++ b/apps/community/Leads/Controllers/LostReasons.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace HubletoApp\Community\Leads\Controllers;
+
+class LostReasons extends \HubletoMain\Core\Controllers\Controller {
+
+  public function getBreadcrumbs(): array
+  {
+    return array_merge(parent::getBreadcrumbs(), [
+      [ 'url' => 'settings', 'content' => $this->translate('Settings') ],
+      [ 'url' => '', 'content' => $this->translate('Lead Lost Reasons') ],
+    ]);
+  }
+
+  public function prepareView(): void
+  {
+    parent::prepareView();
+    $this->setView('@HubletoApp:Community:Leads/LostReasons.twig');
+  }
+
+}

--- a/apps/community/Leads/Loader.php
+++ b/apps/community/Leads/Loader.php
@@ -18,6 +18,7 @@ class Loader extends \HubletoMain\Core\App
       '/^leads\/get-calendar-events\/?$/' => Controllers\Api\GetCalendarEvents::class,
       '/^leads\/convert-to-deal\/?$/' => Controllers\Api\ConvertLead::class,
       '/^settings\/lead-tags\/?$/' => Controllers\Tags::class,
+      '/^settings\/lead-lost-reasons\/?$/' => Controllers\LostReasons::class,
       '/^leads\/boards\/lead-value-by-score\/?$/' => Controllers\Boards\LeadValueByScore::class,
     ]);
 
@@ -25,6 +26,11 @@ class Loader extends \HubletoMain\Core\App
       'title' => $this->translate('Lead Tags'),
       'icon' => 'fas fa-tags',
       'url' => 'settings/lead-tags',
+    ]);
+    $this->main->addSetting($this, [
+      'title' => $this->translate('Lead Lost Reasons'),
+      'icon' => 'fas fa-tags',
+      'url' => 'settings/lead-lost-reasons',
     ]);
 
     $calendarManager = $this->main->apps->community('Calendar')->calendarManager;
@@ -62,7 +68,9 @@ class Loader extends \HubletoMain\Core\App
       $mLeadProduct = new \HubletoApp\Community\Leads\Models\LeadProduct($this->main);
       $mLeadActivity = new \HubletoApp\Community\Leads\Models\LeadActivity($this->main);
       $mLeadDocument = new \HubletoApp\Community\Leads\Models\LeadDocument($this->main);
+      $mLostReasons = new \HubletoApp\Community\Leads\Models\LostReason($this->main);
 
+      $mLostReasons->dropTableIfExists()->install();
       $mLead->dropTableIfExists()->install();
       $mLeadHistory->dropTableIfExists()->install();
       $mLeadTag->dropTableIfExists()->install();
@@ -75,6 +83,11 @@ class Loader extends \HubletoMain\Core\App
       $mLeadTag->record->recordCreate([ 'name' => "Great opportunity", 'color' => '#4caf50' ]);
       $mLeadTag->record->recordCreate([ 'name' => "Duplicate", 'color' => '#9e9e9e' ]);
       $mLeadTag->record->recordCreate([ 'name' => "Needs attention", 'color' => '#795548' ]);
+
+      $mLostReasons->record->recordCreate(["reason" => "Price"]);
+      $mLostReasons->record->recordCreate(["reason" => "Solution"]);
+      $mLostReasons->record->recordCreate(["reason" => "Demand canceled by customer"]);
+      $mLostReasons->record->recordCreate(["reason" => "Other"]);
     }
   }
 

--- a/apps/community/Leads/Models/Lead.php
+++ b/apps/community/Leads/Models/Lead.php
@@ -61,7 +61,7 @@ class Lead extends \HubletoMain\Core\Models\Model
       'status' => (new Integer($this, $this->translate('Status')))->setRequired()->setEnumValues(
         [ $this::STATUS_NEW => 'New', $this::STATUS_IN_PROGRESS => 'In Progress', $this::STATUS_COMPLETED => 'Completed', $this::STATUS_LOST => 'Lost' ]
       ),
-      'lost_reason' => new Text($this, "Reason for Lost"),
+      'lost_reason' => (new Lookup($this, $this->translate("Reason for Lost"), LostReason::class)),
       'shared_folder' => new Varchar($this, "Shared folder (online document storage)"),
       'note' => (new Text($this, $this->translate('Notes'))),
       'source_channel' => (new Integer($this, $this->translate('Source channel')))->setEnumValues([

--- a/apps/community/Leads/Models/LostReason.php
+++ b/apps/community/Leads/Models/LostReason.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace HubletoApp\Community\Leads\Models;
+
+use ADIOS\Core\Db\Column\Varchar;
+
+class LostReason extends \HubletoMain\Core\Models\Model
+{
+  public string $table = 'lead_lost_reasons';
+  public string $recordManagerClass = RecordManagers\LostReason::class;
+  public ?string $lookupSqlValue = '{%TABLE%}.reason';
+
+  public function describeColumns(): array
+  {
+    return array_merge(parent::describeColumns(), [
+      'reason' => (new Varchar($this, $this->translate('Lost Reason')))->setRequired(),
+    ]);
+  }
+
+  public function describeTable(): \ADIOS\Core\Description\Table
+  {
+    $description = parent::describeTable();
+    $description->ui['title'] = 'Lead Lost Reasons';
+    $description->ui['addButtonText'] = 'Add Reason';
+    return $description;
+  }
+
+}

--- a/apps/community/Leads/Models/RecordManagers/LostReason.php
+++ b/apps/community/Leads/Models/RecordManagers/LostReason.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace HubletoApp\Community\Leads\Models\RecordManagers;
+
+class LostReason extends \HubletoMain\Core\RecordManager
+{
+  public $table = 'lead_lost_reasons';
+
+}

--- a/apps/community/Leads/Views/LostReasons.twig
+++ b/apps/community/Leads/Views/LostReasons.twig
@@ -1,0 +1,1 @@
+<app-table string:model="HubletoApp/Community/Leads/Models/LostReason"></app-table>

--- a/apps/community/Products/Loader.php
+++ b/apps/community/Products/Loader.php
@@ -11,7 +11,7 @@ class Loader extends \HubletoMain\Core\App
     $this->main->router->httpGet([
       '/^products\/?$/' => Controllers\Products::class,
       '/^products\/groups\/?$/' => Controllers\Groups::class,
-      '/^products\/groups(\/(?<recordId>\d+))?\/?$/' => Controllers\Suppliers::class,
+      '/^products\/groups(\/(?<recordId>\d+))?\/?$/' => Controllers\Groups::class,
       '/^products\/suppliers\/?$/' => Controllers\Suppliers::class,
       '/^products\/suppliers(\/(?<recordId>\d+))?\/?$/' => Controllers\Suppliers::class,
     ]);


### PR DESCRIPTION
- fixed an issue where new deals would throw an error due to an undefined probability wai-blue/adios#32
- added a new model `Lost Reason` to both the Lead app and the Deal app #121 
  - the forms of these apps were changed accordingly
- added a functionality where a manual change of the Deal Result will change the Pipeline to a first Pipeline Step that has the same result value #129 
- some fixes