### PR TITLE
delete deal result, pipeline fix

### DIFF
--- a/apps/community/Deals/Components/FormDeal.tsx
+++ b/apps/community/Deals/Components/FormDeal.tsx
@@ -32,6 +32,7 @@ export interface FormDealState extends HubletoFormState {
   tableDealProductsDescription: any,
   tableDealDocumentsDescription: any,
   tablesKey: number,
+  pipelineFirstLoad: boolean;
 }
 
 export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealState> {
@@ -68,6 +69,7 @@ export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealSt
       tableDealProductsDescription: null,
       tableDealDocumentsDescription: null,
       tablesKey: 0,
+      pipelineFirstLoad: false,
     };
     this.onCreateActivityCallback = this.onCreateActivityCallback.bind(this);
   }
@@ -226,16 +228,11 @@ export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealSt
       if (R.HISTORY.length > 1 && (R.HISTORY[0].id < R.HISTORY[R.HISTORY.length-1].id))
         R.HISTORY = this.state.record.HISTORY.reverse();
     }
-    console.log(R);
-    // if (R.id > 0 && globalThis.main.idUser != R.id_owner && !this.state.recordChanged) {
-    //   return (
-    //     <>
-    //       <div className='w-full h-full flex flex-col justify-center'>
-    //         <span className='text-center'>This deal belongs to a different user</span>
-    //       </div>
-    //     </>
-    //   )
-    // }
+
+    if (R.id == undefined && this.state.pipelineFirstLoad == false) {
+      this.pipelineChange(this.state.record.id_pipeline);
+      this.setState({pipelineFirstLoad: true});
+    }
 
     const pipeline = <div className='card mt-2'>
       <div className='card-header'>
@@ -445,7 +442,9 @@ export default class FormDeal<P, S> extends HubletoForm<FormDealProps,FormDealSt
             readonly: R.is_archived,
             onChange: (input: any, value: any) => {
               this.updateRecord({lost_reason: null});
-              this.changePipelineStepFromResult();
+              if (this.state.record.PIPELINE && this.state.record.PIPELINE.STEPS?.length > 0) {
+                this.changePipelineStepFromResult();
+              }
             }
           }
         )}

--- a/apps/community/Deals/Models/Deal.php
+++ b/apps/community/Deals/Models/Deal.php
@@ -29,7 +29,6 @@ class Deal extends \HubletoMain\Core\Models\Model
   public ?string $lookupSqlValue = 'concat(ifnull({%TABLE%}.identifier, ""), " ", ifnull({%TABLE%}.title, ""))';
   public ?string $lookupUrlDetail = 'deals/{%ID%}';
 
-  const RESULT_QUALIFIED = 0;
   const RESULT_PENDING = 1;
   const RESULT_WON = 2;
   const RESULT_LOST = 3;
@@ -83,9 +82,8 @@ class Deal extends \HubletoMain\Core\Models\Model
       ]),
       'is_archived' => (new Boolean($this, $this->translate('Archived')))->setDefaultValue(0),
       'deal_result' => (new Integer($this, $this->translate('Deal Result')))
-        ->setEnumValues([self::RESULT_QUALIFIED => "Qualify for buy", self::RESULT_PENDING => "Pending", self::RESULT_WON => "Won", self::RESULT_LOST => "Lost"])
+        ->setEnumValues([self::RESULT_PENDING => "Pending", self::RESULT_WON => "Won", self::RESULT_LOST => "Lost"])
         ->setEnumCssClasses([
-          self::RESULT_QUALIFIED => 'bg-orange-100 text-orange-800',
           self::RESULT_PENDING => 'bg-yellow-100 text-yellow-800',
           self::RESULT_WON => 'bg-green-100 text-green-800',
           self::RESULT_LOST => 'bg-red-100 text-red-800',

--- a/apps/community/Leads/Controllers/Api/ConvertToDeal.php
+++ b/apps/community/Leads/Controllers/Api/ConvertToDeal.php
@@ -34,7 +34,6 @@ class ConvertToDeal extends \HubletoMain\Core\Controllers\Controller
 
     $mDeal = new Deal($this->main);
     $mDealHistory = new DealHistory($this->main);
-    $mDealProduct = new DealProduct($this->main);
     $mDealDocument = new DealDocument($this->main);
     $deal = null;
 
@@ -42,14 +41,6 @@ class ConvertToDeal extends \HubletoMain\Core\Controllers\Controller
     $defaultPipeline = 1;
     $defaultPipelineFirstStep =(int) $mPipepelineStep->record
       ->where("id_pipeline", $defaultPipeline)
-      ->orderBy("id", "asc")
-      ->first()
-      ->id
-    ;
-
-    $resultQualifiedStep = (int) $mPipepelineStep->record
-      ->where("id_pipeline", $defaultPipeline)
-      ->where("set_result", $mDeal::RESULT_QUALIFIED)
       ->orderBy("id", "asc")
       ->first()
       ->id
@@ -72,9 +63,9 @@ class ConvertToDeal extends \HubletoMain\Core\Controllers\Controller
         "source_channel" => $lead->source_channel,
         "is_archived" => $lead->is_archived,
         "id_lead" => $lead->id,
-        "deal_result" => $resultQualifiedStep ? $mDeal::RESULT_QUALIFIED : $mDeal::RESULT_PENDING,
+        "deal_result" => $mDeal::RESULT_PENDING,
         "id_pipeline" => $defaultPipeline ?? null,
-        "id_pipeline_step" =>  $resultQualifiedStep ? $resultQualifiedStep : $defaultPipelineFirstStep ?? null,
+        "id_pipeline_step" => $defaultPipelineFirstStep ?? null,
       ]);
 
       $lead->status = $mLead::STATUS_COMPLETED;

--- a/apps/community/Pipeline/Components/FormPipeline.tsx
+++ b/apps/community/Pipeline/Components/FormPipeline.tsx
@@ -128,14 +128,14 @@ export default class FormPipeline<P, S> extends HubletoForm<FormPipelineProps, F
                     order: { type: "int", title: "Order" },
                     color: { type: "color", title: "Color" },
                     probability: { type: "int", title: "Probability", unit: "%" },
-                    set_result: { type: "integer", title: "Sets result of a deal to", enumValues: { 0: "Qualified to buy", 1: "Pending", 2: "Won", 3: "Lost"} },
+                    set_result: { type: "integer", title: "Sets result of a deal to", enumValues: {1: "Pending", 2: "Won", 3: "Lost"} },
                   },
                   inputs: {
                     name: { type: "varchar", title: "Name" },
                     order: { type: "int", title: "Order" },
                     color: { type: "color", title: "Color" },
                     probability: { type: "int", title: "Probability", unit: "%" },
-                    set_result: { type: "integer", title: "Sets result of a deal to", enumValues: { 0: "Qualified to buy", 1: "Pending", 2: "Won", 3: "Lost"} },
+                    set_result: { type: "integer", title: "Sets result of a deal to", enumValues: {1: "Pending", 2: "Won", 3: "Lost"} },
                   },
                 }}
               ></TablePipelineSteps>

--- a/apps/community/Pipeline/Loader.php
+++ b/apps/community/Pipeline/Loader.php
@@ -48,7 +48,7 @@ class Loader extends \HubletoMain\Core\App
 
       $idPipeline = $mPipeline->record->recordCreate([ "name" => "Default pipeline" ])['id'];
       $mPipelineStep->record->recordCreate([ 'name' => 'Prospecting', 'order' => 1, 'color' => '#838383', 'id_pipeline' => $idPipeline , "set_result" => Deal::RESULT_PENDING, "probability" => 1]);
-      $mPipelineStep->record->recordCreate([ 'name' => 'Qualified to buy', 'order' => 2, 'color' => '#d8a082', 'id_pipeline' => $idPipeline, "set_result" => Deal::RESULT_QUALIFIED, "probability" => 10]);
+      $mPipelineStep->record->recordCreate([ 'name' => 'Qualified to buy', 'order' => 2, 'color' => '#d8a082', 'id_pipeline' => $idPipeline, "set_result" => Deal::RESULT_PENDING, "probability" => 10]);
       $mPipelineStep->record->recordCreate([ 'name' => 'Proposal & Quote Sent', 'order' => 3, 'color' => '#d1cf79', 'id_pipeline' => $idPipeline, "set_result" => Deal::RESULT_PENDING , "probability" => 30]);
       $mPipelineStep->record->recordCreate([ 'name' => 'Negotiation & Adjustments', 'order' => 4, 'color' => '#79d1a5', 'id_pipeline' => $idPipeline, "set_result" => Deal::RESULT_PENDING , "probability" => 50]);
       $mPipelineStep->record->recordCreate([ 'name' => 'Decision-Making Phase', 'order' => 5, 'color' => '#82b3d8', 'id_pipeline' => $idPipeline, "set_result" => Deal::RESULT_PENDING , "probability" => 70]);

--- a/apps/community/Pipeline/Models/PipelineStep.php
+++ b/apps/community/Pipeline/Models/PipelineStep.php
@@ -27,7 +27,7 @@ class PipelineStep extends \HubletoMain\Core\Models\Model
       'probability' => (new Integer($this, $this->translate('Probability')))->setRequired()->setUnit("%"),
       'id_pipeline' => (new Lookup($this, $this->translate("Pipeline"), Pipeline::class))->setRequired(),
       'set_result' => (new Integer($this, $this->translate('Set result of a deal to')))->setRequired()
-        ->setEnumValues([Deal::RESULT_QUALIFIED => "Qualified to buy", Deal::RESULT_PENDING => "Pending", Deal::RESULT_WON => "Won",  Deal::RESULT_LOST => "Lost"])
+        ->setEnumValues([Deal::RESULT_PENDING => "Pending", Deal::RESULT_WON => "Won",  Deal::RESULT_LOST => "Lost"])
     ]);
   }
 


### PR DESCRIPTION
- removed the "qualify for buy" result from deals
- fixed an issue where choosing the result of the deal without pipeline steps present would result in a component crash
- fixed an issue where if creating a new deal, pipeline steps would not load.