### PR TITLE
Various fixes for calendar app and other fixes

### DIFF
--- a/apps/community/Calendar/Calendar.php
+++ b/apps/community/Calendar/Calendar.php
@@ -16,8 +16,11 @@ class Calendar extends \HubletoMain\Core\Calendar {
   {
     $query = $mActivity->record->prepareReadQuery()
       ->with('ACTIVITY_TYPE')
-      ->where($mActivity->table.".date_start", ">=", $dateStart)
-      ->where($mActivity->table.".date_start", "<=", $dateEnd)
+      ->whereRaw("
+        ({$mActivity->table}.date_start >= '{$dateStart}' AND {$mActivity->table}.date_start <= '{$dateEnd}')
+        OR ({$mActivity->table}.date_end >= '{$dateStart}' AND {$mActivity->table}.date_end <= '{$dateEnd}')
+        OR ({$mActivity->table}.date_start <= '{$dateStart}' AND {$mActivity->table}.date_end >= '{$dateEnd}')
+      ")
     ;
 
     if (isset($filter['completed'])) $query = $query->where('completed', $filter['completed']);

--- a/apps/community/Calendar/Components/FormActivitySelector.tsx
+++ b/apps/community/Calendar/Components/FormActivitySelector.tsx
@@ -20,6 +20,7 @@ export default class FormActivitySelector<P, S> extends Component<FormActivitySe
   translationContext: string = 'HubletoApp\\Community\\Calendar\\Loader::Components\\FormActivitySelector';
 
   render(): JSX.Element {
+    var calendarConfigs = this.props.calendarConfigs;
     return (
       <>
         <div className='modal-header'>
@@ -40,13 +41,13 @@ export default class FormActivitySelector<P, S> extends Component<FormActivitySe
           Choose calendar to which the event should be created.
         </div>
         <div className='flex gap-2 flex-col px-4 mt-4'>
-          {this.props.calendarConfigs.map((item, index) => {
-            if (item.addNewActivityButtonText) {
+          {Object.keys(this.props.calendarConfigs).map((item, index) => {
+            if (calendarConfigs[item]["addNewActivityButtonText"]) {
               return <>
                 <button
                   key={index}
                   className='btn btn-transparent btn-large'
-                  style={{borderLeft: '3em solid ' + item.color}}
+                  style={{borderLeft: '3em solid ' + calendarConfigs[item]["color"]}}
                   onClick={() => {
                     //calculate half an hour from time_start
                     if (this.props.clickConfig?.time && this.props.clickConfig?.date) {
@@ -54,7 +55,7 @@ export default class FormActivitySelector<P, S> extends Component<FormActivitySe
                       var newMoment = momentDateTime.add(30, 'minutes');
                     }
 
-                    this.setState({formSelected: globalThis.main.renderReactElement(item.formComponent,
+                    this.setState({formSelected: globalThis.main.renderReactElement(calendarConfigs[item]["formComponent"],
                       {
                         description: {
                           defaultValues: {
@@ -73,8 +74,8 @@ export default class FormActivitySelector<P, S> extends Component<FormActivitySe
                     });
                   }}
                 >
-                  {item.icon ? <span className='icon'><i className={item.icon}></i></span> : null}
-                  <span className='text text-center self-center !h-auto text-lg'>{item.addNewActivityButtonText}</span>
+                  {item.icon ? <span className='icon'><i className={calendarConfigs[item]["icon"]}></i></span> : null}
+                  <span className='text text-center self-center !h-auto text-lg'>{calendarConfigs[item]["addNewActivityButtonText"]}</span>
                 </button>
               </>
             } else {

--- a/apps/community/Projects/Loader.php
+++ b/apps/community/Projects/Loader.php
@@ -46,6 +46,9 @@ class Loader extends \HubletoMain\Core\App
       (new Models\Project($this->main))->dropTableIfExists()->install();
     }
     if ($round == 2) {
+
+    }
+    if ($round == 3) {
       $mPhase = new Models\Phase($this->main);
       $mPhase->record->recordCreate(['name' => 'Early preparation', 'order' => 1, 'color' => '#344556']);
       $mPhase->record->recordCreate(['name' => 'Advanced preparation', 'order' => 2, 'color' => '#6830a5']);
@@ -54,9 +57,6 @@ class Loader extends \HubletoMain\Core\App
       $mPhase->record->recordCreate(['name' => 'Advanced implementation', 'order' => 5, 'color' => '#a38f9a']);
       $mPhase->record->recordCreate(['name' => 'Final implementation', 'order' => 6, 'color' => '#44879a']);
       $mPhase->record->recordCreate(['name' => 'Delivery', 'order' => 7, 'color' => '#74809a']);
-    }
-    if ($round == 3) {
-      // do something in the 3rd round, if required
     }
   }
 

--- a/src/cli/Agent/Project/GenerateDemoData.php
+++ b/src/cli/Agent/Project/GenerateDemoData.php
@@ -522,7 +522,7 @@ class GenerateDemoData extends \HubletoMain\Cli\Agent\Command
         "id_owner" => rand(1, 4),
         "source_channel" => rand(1,7),
         "is_archived" => false,
-        "status" => (rand(0, 10) == 5 ? $mLead::STATUS_LOST : $mLead::STATUS_CONTACTED),
+        "status" => (rand(0, 10) == 5 ? $mLead::STATUS_CLOSED : $mLead::STATUS_CONTACTED),
         "date_created" => $leadDateCreated,
         "score" => rand(1, 10),
       ])['id'];


### PR DESCRIPTION
- fixed and issue where the activity selector form would crash due to incorrect looping of `calendarConfig` prop #163 
- adjusted the search of activities to include multi-day activities
  -  for example, if the user is in the week view and at least one activity spans into the next week, switching to the next week would not show the activity
  - similarly if the activity spanned more then 3 weeks, the activity would not show in the second week
- fixed an issue with the installation of the Projects app
- fixed an where an obsolete constant value of the Lead model was used during the generation of dummy data