### PR TITLE
changes to documents app

### DIFF
--- a/apps/Documents/Components/Browser.tsx
+++ b/apps/Documents/Components/Browser.tsx
@@ -133,7 +133,7 @@ export default class Browser extends Table<BrowserProps, BrowserState> {
               }
             }}
           >
-            <span className="text">{item.name}</span>
+            <span className="text">{item.name} {isLast ? <i className='fa fa-chevron-down'></i> : <></>}</span>
           </button>;
         })}
         <button
@@ -194,9 +194,20 @@ export default class Browser extends Table<BrowserProps, BrowserState> {
             modal={this.refFolderPropertiesModal}
             uid='create_sub_folder_form'
             model='Hubleto/App/Community/Documents/Models/Folder'
-            customEndpointParams={{idParentFolder: this.state.folderContent.folder.id}}
+            isInlineEditing={true}
+            customEndpointParams={{idParentFolder: this.state.folderContent.folder.id, noSelfParent: true}}
             id={this.state.showFolderProperties}
-            onSaveCallback={() => {this.loadData(); this.setState({showFolderProperties: 0});}}
+            onSaveCallback={(form, saveResponse, customSaveOptions) => {
+              //if the folder is being moved to another parent folder
+              console.log(saveResponse.originalRecord.id_parent_folder, saveResponse.savedRecord.id_parent_folder);
+              if (saveResponse.originalRecord.id_parent_folder != saveResponse.savedRecord.id_parent_folder) {
+                this.changeFolder("_ROOT_", []);
+              } else {
+                this.loadData();
+              }
+
+              this.setState({showFolderProperties: 0});
+            }}
             onClose={() => { this.setState({showFolderProperties: 0}); }}
             onDeleteCallback={() => {
               const secondLastIndex = this.state.path.length - 2;

--- a/apps/Documents/Components/Browser.tsx
+++ b/apps/Documents/Components/Browser.tsx
@@ -199,7 +199,6 @@ export default class Browser extends Table<BrowserProps, BrowserState> {
             id={this.state.showFolderProperties}
             onSaveCallback={(form, saveResponse, customSaveOptions) => {
               //if the folder is being moved to another parent folder
-              console.log(saveResponse.originalRecord.id_parent_folder, saveResponse.savedRecord.id_parent_folder);
               if (saveResponse.originalRecord.id_parent_folder != saveResponse.savedRecord.id_parent_folder) {
                 this.changeFolder("_ROOT_", []);
               } else {

--- a/apps/Documents/Components/TableDocuments.tsx
+++ b/apps/Documents/Components/TableDocuments.tsx
@@ -35,7 +35,7 @@ export default class TableDocuments extends HubletoTable<TableDocumentsProps, Ta
 
   getFormModalProps(): any {
     let params = super.getFormModalProps();
-    params.type = 'centered small';
+    params.type = 'right';
     return params;
   }
 
@@ -60,7 +60,7 @@ export default class TableDocuments extends HubletoTable<TableDocumentsProps, Ta
       return super.renderCell(columnName, column, data, options);
     }
   }
-  
+
   renderForm(): JSX.Element {
     let formProps: FormDocumentProps = this.getFormProps();
     return <FormDocument {...formProps}/>;

--- a/apps/Documents/Components/TableFolders.tsx
+++ b/apps/Documents/Components/TableFolders.tsx
@@ -1,0 +1,44 @@
+import React, { Component } from 'react'
+import HubletoTable, { HubletoTableProps, HubletoTableState } from '@hubleto/react-ui/ext/HubletoTable';
+
+interface TableFoldersProps extends HubletoTableProps {}
+interface TableFoldersState extends HubletoTableState {}
+
+export default class TableFolders extends HubletoTable<TableFoldersProps, TableFoldersState> {
+  static defaultProps = {
+    ...HubletoTable.defaultProps,
+    formUseModalSimple: true,
+    orderBy: {
+      field: "id",
+      direction: "desc"
+    },
+    model: 'Hubleto/App/Community/Documents/Models/Folder',
+  }
+
+  props: TableFoldersProps;
+  state: TableFoldersState;
+
+  translationContext: string = 'Hubleto\\App\\Community\\Documents\\Loader';
+  translationContextInner: string = 'Components\\TableFolders';
+
+  constructor(props: TableFoldersProps) {
+    super(props);
+    this.state = this.getStateFromProps(props);
+  }
+
+  getStateFromProps(props: TableFoldersProps) {
+    return {
+      ...super.getStateFromProps(props),
+    }
+  }
+
+  getFormModalProps(): any {
+    let params = super.getFormModalProps();
+    params.type = 'right';
+    return params;
+  }
+
+  setRecordFormUrl(id: number) {
+    window.history.pushState({}, "", globalThis.main.config.projectUrl + '/documents/' + (id > 0 ? id : 'add'));
+  }
+}

--- a/apps/Documents/Controllers/Browse.php
+++ b/apps/Documents/Controllers/Browse.php
@@ -7,7 +7,7 @@ class Browse extends \Hubleto\Erp\Controller
   public function getBreadcrumbs(): array
   {
     return array_merge(parent::getBreadcrumbs(), [
-      [ 'url' => 'documents/browse', 'content' => $this->translate('Browse') ],
+      [ 'url' => 'documents/browse', 'content' => $this->translate('Document Browser') ],
     ]);
   }
 

--- a/apps/Documents/Controllers/Folders.php
+++ b/apps/Documents/Controllers/Folders.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Hubleto\App\Community\Documents\Controllers;
+
+class Folders extends \Hubleto\Erp\Controller
+{
+  public function getBreadcrumbs(): array
+  {
+    return array_merge(parent::getBreadcrumbs(), [
+      // [ 'url' => 'documents', 'content' => $this->translate('Documents') ],
+      [ 'url' => 'documents/folders', 'content' => $this->translate('Folders') ],
+    ]);
+  }
+
+  public function prepareView(): void
+  {
+    parent::prepareView();
+    $this->setView('@Hubleto:App:Community:Documents/Folders.twig');
+  }
+
+}

--- a/apps/Documents/Extendibles/AppMenu.php
+++ b/apps/Documents/Extendibles/AppMenu.php
@@ -10,14 +10,20 @@ class AppMenu extends \Hubleto\Framework\Extendible
       [
         'app' => $this->app,
         'url' => 'documents/browse',
-        'title' => $this->app->translate('Browse'),
+        'title' => $this->app->translate('Document Browser'),
         'icon' => 'fas fa-table',
       ],
       [
         'app' => $this->app,
         'url' => 'documents/list',
-        'title' => $this->app->translate('List'),
+        'title' => $this->app->translate('Documents Table'),
         'icon' => 'fas fa-list',
+      ],
+      [
+        'app' => $this->app,
+        'url' => 'documents/folders',
+        'title' => $this->app->translate('Folders'),
+        'icon' => 'fas fa-folder',
       ],
       [
         'app' => $this->app,

--- a/apps/Documents/Loader.php
+++ b/apps/Documents/Loader.php
@@ -4,12 +4,12 @@ namespace Hubleto\App\Community\Documents;
 
 class Loader extends \Hubleto\Framework\App
 {
-  
+
   /**
    * Inits the app: adds routes, settings, calendars, hooks, menu items, ...
    *
    * @return void
-   * 
+   *
    */
   public function init(): void
   {
@@ -24,6 +24,9 @@ class Loader extends \Hubleto\Framework\App
 
       '/^documents(\/(?<recordId>\d+))?\/?$/' => Controllers\Documents::class,
       '/^documents\/add\/?$/' => ['controller' => Controllers\Documents::class, 'vars' => ['recordId' => -1]],
+
+      '/^documents\/folders\/?$/' => Controllers\Folders::class,
+      '/^documents\/folders\/add\/?$/' => ['controller' => Controllers\Folders::class, 'vars' => ['recordId' => -1]],
 
       '/^documents\/templates(\/(?<recordId>\d+))?\/?$/' => Controllers\Templates::class,
       '/^documents\/templates\/add\/?$/' => ['controller' => Controllers\Templates::class, 'vars' => ['recordId' => -1]],

--- a/apps/Documents/Models/Folder.php
+++ b/apps/Documents/Models/Folder.php
@@ -10,12 +10,13 @@ class Folder extends \Hubleto\Erp\Model
   public string $table = 'folders';
   public string $recordManagerClass = RecordManagers\Folder::class;
   public ?string $lookupSqlValue = '{%TABLE%}.name';
+  public ?string $lookupUrlAdd = 'documents/folders/add';
 
   public function describeColumns(): array
   {
     return array_merge(parent::describeColumns(), [
-      'uid' => (new Varchar($this, $this->translate('Uid')))->setRequired()->setReadonly()->setDefaultValue(\Hubleto\Framework\Helper::generateUuidV4()),
-      'id_parent_folder' => (new Lookup($this, $this->translate("Parent folder"), Folder::class))->setRequired()->setReadonly()->setDefaultValue($this->router()->urlParamAsInteger('idParentFolder')),
+      'uid' => (new Varchar($this, $this->translate('Uid')))->setRequired()->setReadonly()->setDefaultValue(\Hubleto\Framework\Helper::generateUuidV4())->setDefaultHidden(),
+      'id_parent_folder' => (new Lookup($this, $this->translate("Parent folder"), Folder::class))->setRequired()->setDefaultValue($this->router()->urlParamAsInteger('idParentFolder')),
       'name' => (new Varchar($this, $this->translate('Folder name')))->setRequired()->setCssClass('text-2xl text-primary'),
     ]);
   }
@@ -34,4 +35,12 @@ class Folder extends \Hubleto\Erp\Model
     ]);
   }
 
+   public function describeTable(): \Hubleto\Framework\Description\Table
+  {
+    $description = parent::describeTable();
+    $description->ui['addButtonText'] = 'Add Folder';
+    $description->show(['header', 'fulltextSearch', 'columnSearch']);
+    $description->hide(['footer']);
+    return $description;
+  }
 }

--- a/apps/Documents/Models/RecordManagers/Folder.php
+++ b/apps/Documents/Models/RecordManagers/Folder.php
@@ -22,4 +22,25 @@ class Folder extends \Hubleto\Erp\RecordManager
     return parent::recordCreate($record);
   }
 
+  public function prepareReadQuery(mixed $query = null, int $level = 0): mixed
+  {
+    //disables the _ROOT_ folder record from opening
+    $query = parent::prepareReadQuery($query, $level);
+    $query->where($this->table.".id", "!=", 1);
+    return $query;
+  }
+
+
+  public function prepareLookupQuery(string $search): mixed
+  {
+    //restric the folder to be moved to itself
+    $hubleto = \Hubleto\Erp\Loader::getGlobalApp();
+    $record = $hubleto->router()->urlParamAsArray("formRecord");
+    $query = parent::prepareLookupQuery($search);
+    if ($hubleto->router()->urlParamAsBool("noSelfParent") && isset($record["id"])) {
+      $query->where($this->table.".id", "!=", $record["id"]);
+    }
+
+    return $query;
+  }
 }

--- a/apps/Documents/Views/Folders.twig
+++ b/apps/Documents/Views/Folders.twig
@@ -1,0 +1,6 @@
+<h1 class="app-main-title">{{ translate("Folders") }}</h1>
+
+<app-table
+  int:record-id="{{ viewParams.recordId }}"
+  string:model="Hubleto/App/Community/Documents/Models/Folder"
+></app-table>


### PR DESCRIPTION
- added the folder view and table
- added an add button to the parent folder lookup to easily create new folders though document forms, #285 
- added new save callback functionality when working with documents and folders in the Browser
- added restrictions to folder records
  - when editing an existing folder it cannot be selected  as the parent folder
  - the root folder wont be shown in the folder table and cannot be accessed 
- graphical adjustments for the Document app