### PR TITLE
worksheet steps creation bug fix

### DIFF
--- a/apps/Workflow/Components/FormWorkflow.tsx
+++ b/apps/Workflow/Components/FormWorkflow.tsx
@@ -8,6 +8,7 @@ interface FormWorkflowProps extends HubletoFormProps {}
 
 interface FormWorkflowState extends HubletoFormState {
   tablesKey: number,
+  newStepId: number,
 }
 
 export default class FormWorkflow<P, S> extends HubletoForm<FormWorkflowProps, FormWorkflowState> {
@@ -27,6 +28,7 @@ export default class FormWorkflow<P, S> extends HubletoForm<FormWorkflowProps, F
     this.state = {
       ...this.getStateFromProps(props),
       tablesKey: 0,
+      newStepId: -1,
     };
   }
 
@@ -78,10 +80,11 @@ export default class FormWorkflow<P, S> extends HubletoForm<FormWorkflowProps, F
             onClick={() => {
               if (!R.STEPS) R.STEPS = [];
               R.STEPS.push({
+                id: this.state.newStepId,
                 id_workflow: { _useMasterRecordId_: true },
               });
               this.updateRecord(R, () => {
-                this.setState({ isInlineEditing: true});
+                this.setState({ isInlineEditing: true, newStepId: this.state.newStepId-1});
               });
             }}
           >
@@ -101,6 +104,7 @@ export default class FormWorkflow<P, S> extends HubletoForm<FormWorkflowProps, F
             onRowClick={() => this.setState({isInlineEditing: true})}
             onChange={(table: TableWorkflowSteps) => {
               this.updateRecord({ STEPS: table.state.data?.data });
+              this.setState({updatingRecord: true});
             }}
             description={{
               ui: {

--- a/apps/Workflow/Models/Workflow.php
+++ b/apps/Workflow/Models/Workflow.php
@@ -21,7 +21,7 @@ class Workflow extends \Hubleto\Erp\Model
       'name' => (new Varchar($this, $this->translate('Name')))->setRequired()->setDefaultVisible()->setIcon(self::COLUMN_NAME_DEFAULT_ICON),
       'order' => (new Integer($this, $this->translate('Order')))->setRequired()->setDefaultVisible(),
       'description' => (new Varchar($this, $this->translate('Description')))->setDefaultVisible(),
-      'group' => (new Varchar($this, $this->translate('Group')))->setDefaultVisible()->setPredefinedValues([
+      'group' => (new Varchar($this, $this->translate('Group')))->setRequired()->setDefaultVisible()->setPredefinedValues([
         'deals',
         'orders',
         'projects',
@@ -65,7 +65,7 @@ class Workflow extends \Hubleto\Erp\Model
   {
     $fWorkflowSteps = [
       'title' => $title,
-      'type' => 'multipleSelectButtons', 
+      'type' => 'multipleSelectButtons',
       'options' => [],
       'colors' => [],
     ];


### PR DESCRIPTION
- fixed a bug where deleting newly created workflow steps would also delete other ones
- added a `required` flag to the `group` column in the Workflow model due to the functionality of the Workflow view

#279
