### PR TITLE
invoice creation from orders

### DIFF
--- a/apps/Invoices/Controllers/Api/CreateInvoiceFromOrder.php
+++ b/apps/Invoices/Controllers/Api/CreateInvoiceFromOrder.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Hubleto\App\Community\Invoices\Controllers\Api;
+
+use Exception;
+use Hubleto\App\Community\Invoices\Models\Invoice;
+use Hubleto\App\Community\Invoices\Models\Item as InvoiceItem;
+use Hubleto\App\Community\Orders\Models\Item;
+use Hubleto\App\Community\Orders\Models\Order;
+
+class CreateInvoiceFromOrder extends \Hubleto\Erp\Controllers\ApiController
+{
+  public function renderJson(): array
+  {
+    $idOrder = $this->router()->urlParamAsInteger("idOrder");
+
+    if ($idOrder <= 0) {
+      throw new Exception("The order for converting was not set");
+    }
+
+    /** @var Order */
+    $mOrder = $this->getModel(Order::class);
+
+    /** @var Item */
+    $mOrderItem = $this->getModel(Item::class);
+
+    /** @var Invoice */
+    $mInvoice = $this->getModel(Invoice::class);
+
+    /** @var InvoiceItem */
+    $mInvoiceItem = $this->getModel(InvoiceItem::class);
+    try {
+
+      $order = $mOrder->record->prepareReadQuery()->where($mOrder->table . ".id", $idOrder)->with("ITEMS")->first();
+      if (!$order) {
+        throw new Exception("Order was not found.");
+      }
+
+      $idInvoice = $mInvoice->record->recordCreate([
+        'inbound_outbound' => $order->purchase_sales,
+        'id_issued_by' => $this->getService(\Hubleto\Framework\AuthProvider::class)->getUserId() ,
+        'id_customer' => $order->id_customer ,
+        'id_supplier' => $order->id_supplier ,
+        'type' => Invoice::TYPE_STANDARD ,
+        'number' => $order->identifier ,
+        'number_external' => $order->identifier_external,
+        //Most of the data bellow is created/passed in onBeforeCreate in the Invoice model using the invoice profile
+        //'vs' => $order->identifier_external ,
+        //'cs' => $order-> ,
+        //'ss' => $order-> ,
+        //'date_issue' => date("Y-m-d") ,
+        //'date_delivery' => date("Y-m-d") ,
+        //'date_due' => strtotime(date("Y-m-d") . " + 14 days") ,// TODO: this value should be choosable
+        //'date_payment' => $order-> ,
+        //'date_sent' => $order-> ,
+        //'id_currency' => $order->id_currency ,
+        'total_excl_vat' => $order->price_excl_vat ,
+        'total_incl_vat' => $order->price_incl_vat ,
+        //'total_payments' => $order-> ,
+        'notes' => $order->note ,
+      ])["id"];
+
+      foreach ($order->ITEMS as $item) {
+        $idInvoiceItem = $mInvoiceItem->record->recordCreate([
+          'id_invoice' => $idInvoice,
+          'id_customer' => $order->id_customer,
+          'id_order' => $order->id,
+          'id_order_item' => $item->id,
+          'item' => $item->title,
+          'unit_price' => $item->unit_price,
+          'amount' => $item->amount,
+          'discount' => $item->discount,
+          'vat' => $item->vat ,
+          // 'price_excl_vat' => $item->price_excl_vat ,
+          // 'price_vat' => $item->price_vat ,
+          // 'price_incl_vat' => $item->price_incl_vat ,
+        ])["id"];
+        $item->id_invoice_item = $idInvoiceItem;
+        $item->save();
+      }
+
+    } catch (Exception $e) {
+      return [
+        "status" => "failed",
+        "error" => $e
+      ];
+    }
+
+    return [
+      "status" => "success",
+      "idInvoice" => $idInvoice,
+      //"title" => str_replace(" ", "+", (string) $project['title'])
+    ];
+  }
+
+}

--- a/apps/Invoices/Loader.php
+++ b/apps/Invoices/Loader.php
@@ -9,7 +9,7 @@ class Loader extends \Hubleto\Framework\App
    * Inits the app: adds routes, settings, calendars, event listeners, menu items, ...
    *
    * @return void
-   * 
+   *
    */
   public function init(): void
   {
@@ -33,6 +33,7 @@ class Loader extends \Hubleto\Framework\App
       '/^invoices\/payment-methods\/add?\/?$/' => ['controller' => Controllers\PaymentMethods::class, 'vars' => [ 'recordId' => -1 ]],
       '/^invoices\/items(\/(?<recordId>\d+))?\/?$/' => Controllers\Items::class,
       '/^invoices\/items\/add?\/?$/' => ['controller' => Controllers\Items::class, 'vars' => [ 'recordId' => -1 ]],
+      '/^invoices\/api\/create-invoice-from-order?\/?$/' => Controllers\Api\CreateInvoiceFromOrder::class,
     ]);
 
     $this->addSearchSwitch('i', 'invoices');
@@ -47,9 +48,9 @@ class Loader extends \Hubleto\Framework\App
    * [Description for installTables]
    *
    * @param int $round
-   * 
+   *
    * @return void
-   * 
+   *
    */
   public function installTables(int $round): void
   {
@@ -95,7 +96,7 @@ class Loader extends \Hubleto\Framework\App
    * [Description for getSidebarBadgeNumber]
    *
    * @return int
-   * 
+   *
    */
   public function getSidebarBadgeNumber(): int
   {
@@ -113,7 +114,7 @@ class Loader extends \Hubleto\Framework\App
    * [Description for renderSecondSidebar]
    *
    * @return string
-   * 
+   *
    */
   public function renderSecondSidebar(): string
   {
@@ -182,15 +183,15 @@ class Loader extends \Hubleto\Framework\App
    * Implements fulltext search functionality for tasks
    *
    * @param array $expressions List of expressions to be searched and glued with logical 'or'.
-   * 
+   *
    * @return array
-   * 
+   *
    */
   public function search(array $expressions): array
   {
     $mInvoice = $this->getModel(Models\Invoice::class);
     $qInvoices = $mInvoice->record->prepareReadQuery();
-    
+
     foreach ($expressions as $e) {
       $qInvoices = $qInvoices->having(function($q) use ($e) {
         $e = (string) $e;

--- a/apps/Invoices/Loader.tsx
+++ b/apps/Invoices/Loader.tsx
@@ -1,4 +1,5 @@
 import App from '@hubleto/react-ui/core/App'
+import request from "@hubleto/react-ui/core/Request";
 import TableProfiles from "./Components/TableProfiles"
 import TableInvoices from "./Components/TableInvoices"
 import TableItems from "./Components/TableItems"
@@ -13,6 +14,21 @@ class InvoicesApp extends App {
     globalThis.hubleto.registerReactComponent('InvoicesTableInvoices', TableInvoices);
     globalThis.hubleto.registerReactComponent('InvoicesTableItems', TableItems);
     globalThis.hubleto.registerReactComponent('InvoicesTablePayments', TablePayments);
+
+    globalThis.hubleto.getApp('Hubleto/App/Community/Orders').addFormHeaderButton(
+      'Create invoice',
+      (form: any) => {
+        request.get(
+          'invoices/api/create-invoice-from-order',
+          {idOrder: form.state.record.id},
+          (data: any) => {
+            if (data.status == "success") {
+              globalThis.window.open(globalThis.hubleto.config.projectUrl + '/invoices/' + data.idInvoice);
+            }
+          }
+        );
+      }
+    )
   }
 }
 

--- a/apps/Orders/Models/Item.php
+++ b/apps/Orders/Models/Item.php
@@ -11,6 +11,7 @@ use Hubleto\Framework\Db\Column\Text;
 use Hubleto\App\Community\Products\Models\Product;
 use Hubleto\App\Community\Products\Controllers\Api\CalculatePrice;
 use Hubleto\App\Community\Auth\Models\User;
+use Hubleto\App\Community\Invoices\Models\Item as InvoiceItem;
 
 class Item extends \Hubleto\Erp\Model
 {
@@ -45,7 +46,7 @@ class Item extends \Hubleto\Erp\Model
 
       'date_due' => (new Date($this, $this->translate('Due date')))->setDefaultVisible()->setDefaultValue(date("Y-m-d")),
       'notes' => (new Text($this, $this->translate('Notes')))->setDefaultVisible(),
-      'id_invoice_item' => (new Lookup($this, $this->translate('Invoice item'), Item::class))->setDefaultVisible(),
+      'id_invoice_item' => (new Lookup($this, $this->translate('Invoice item'), InvoiceItem::class))->setDefaultVisible(),
       'id_owner' => (new Lookup($this, $this->translate('Owner'), User::class))->setReactComponent('InputUserSelect')->setDefaultVisible()->setDefaultValue($this->getService(\Hubleto\Framework\AuthProvider::class)->getUserId()),
       'id_manager' => (new Lookup($this, $this->translate('Manager'), User::class))->setReactComponent('InputUserSelect')->setDefaultVisible()->setDefaultValue($this->getService(\Hubleto\Framework\AuthProvider::class)->getUserId())->setDefaultVisible(),
       'position' => (new Integer($this, $this->translate('Position (in the PDF)')))->setDefaultVisible(),
@@ -116,7 +117,7 @@ class Item extends \Hubleto\Erp\Model
    * [Description for describeForm]
    *
    * @return \Hubleto\Framework\Description\Form
-   * 
+   *
    */
   public function describeForm(): \Hubleto\Framework\Description\Form
   {
@@ -145,19 +146,19 @@ class Item extends \Hubleto\Erp\Model
    * [Description for onBeforeCreate]
    *
    * @param array $record
-   * 
+   *
    * @return array
-   * 
+   *
    */
   public function onBeforeCreate(array $record): array
   {
     $record["price_excl_vat"] = ($this->getService(CalculatePrice::class))->calculatePriceExcludingVat(
-      (float) ($record["sales_price"] ?? 0),
+      (float) ($record["unit_price"] ?? 0),
       (float) ($record["amount"] ?? 0),
       (float) ($record["discount"] ?? 0)
     );
     $record["price_incl_vat"] = ($this->getService(CalculatePrice::class))->calculatePriceIncludingVat(
-      (float) ($record["sales_price"] ?? 0),
+      (float) ($record["unit_price"] ?? 0),
       (float) ($record["amount"] ?? 0),
       (float) ($record["vat"] ?? 0),
       (float) ($record["discount"] ?? 0)
@@ -169,19 +170,19 @@ class Item extends \Hubleto\Erp\Model
    * [Description for onBeforeUpdate]
    *
    * @param array $record
-   * 
+   *
    * @return array
-   * 
+   *
    */
   public function onBeforeUpdate(array $record): array
   {
     $record["price_excl_vat"] = ($this->getService(CalculatePrice::class))->calculatePriceExcludingVat(
-      (float) ($record["sales_price"] ?? 0),
+      (float) ($record["unit_price"] ?? 0),
       (float) ($record["amount"] ?? 0),
       (float) ($record["discount"] ?? 0)
     );
     $record["price_incl_vat"] = ($this->getService(CalculatePrice::class))->calculatePriceIncludingVat(
-      (float) ($record["sales_price"] ?? 0),
+      (float) ($record["unit_price"] ?? 0),
       (float) ($record["amount"] ?? 0),
       (float) ($record["vat"] ?? 0),
       (float) ($record["discount"] ?? 0)


### PR DESCRIPTION
- fixed an issue where `id_invoice_item` was wrongfully pointing to the Item model of the **Order** app and not the Item model of the **Invoice** app
- fixed the recalculation of prices in the `onBeforeCreate` and `onAfterUpdate` callbacks in the Item model in the Order app
- added a injected button from Invoices to the header of the Order that converts a order to an invoice
https://github.com/hubleto/erp/issues/355