### PR TITLE
Add folder history, improve "not enough permissions" error message, and streamline dashboard panel creation

### DIFF
--- a/apps/Auth/Views/NotEnoughPermissions.twig
+++ b/apps/Auth/Views/NotEnoughPermissions.twig
@@ -2,7 +2,7 @@
 
 {% block status %}
   <div class="alert alert-danger">
-    {{ viewParams.message }}
+    {{ translate("You don't have permissions for this panel") }}
   </div>
 {% endblock %}
 
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block button %}
-  <a href="?sign-out" class="btn btn-large">
+  <a href="?sign-out" class="btn btn-large whitespace-nowrap w-max">
     <span class="icon"><i class="fas fa-arrow-right"></i></span>
     <span class="text">{{ translate("Sign out") }}</span>
   </a>

--- a/apps/Auth/Views/layouts/Auth.twig
+++ b/apps/Auth/Views/layouts/Auth.twig
@@ -35,8 +35,8 @@
         <img src="{{ logoUrl }}" class="w-full h-full" />
         {% if secondLogoUrl %} <img src="{{ secondLogoUrl }}"  class="w-full h-full"> {% endif %}
       </div>
-      <div class="form">
-        <form class="content" id="login_form" action="" method="POST">
+      <div class="form min-w-min">
+        <form class="content min-w-min" id="login_form" action="" method="POST">
           <input type="hidden" name="set-language" id="set-language" value="{{ app.getLanguage() }}">
           <input type="hidden" name="authUser" id="authUser" value="1">
 

--- a/apps/Dashboards/Components/TablePanels.tsx
+++ b/apps/Dashboards/Components/TablePanels.tsx
@@ -27,6 +27,15 @@ export default class TablePanels extends Table<TablePanelsProps, TablePanelsStat
     return params;
   }
 
+  getFormProps(): any {
+    let formProps = super.getFormProps();
+    formProps.onSaveCallback = (form: any, saveResponse: any) => {
+      this.reload();
+      if (this.state.recordId === -1) { this.openForm(-1); } 
+    };
+    return formProps;
+  }
+
   constructor(props: TablePanelsProps) {
     super(props);
     this.state = this.getStateFromProps(props);

--- a/apps/Dashboards/Models/Dashboard.php
+++ b/apps/Dashboards/Models/Dashboard.php
@@ -31,7 +31,7 @@ class Dashboard extends \Hubleto\Erp\Model
         ->setDefaultValue($this->authProvider()->getUserId()),
       'title' => (new Varchar($this, $this->translate('Title')))->setRequired()->setDefaultVisible()->setIcon(self::COLUMN_NAME_DEFAULT_ICON),
       'slug' => (new Varchar($this, $this->translate('Slug')))->setRequired()->setDefaultVisible(),
-      'color' => (new Color($this, $this->translate('Color')))->setRequired()->setDefaultVisible()->setIcon(self::COLUMN_COLOR_DEFAULT_ICON),
+      'color' => (new Color($this, $this->translate('Color')))->setDefaultVisible()->setIcon(self::COLUMN_COLOR_DEFAULT_ICON),
       'is_default' => (new Boolean($this, $this->translate('Is default')))->setDefaultVisible()
         ->setDescription($this->translate("By turning this on you will change the dashboard shown on the Homepage"))
       ,

--- a/apps/Documents/Components/Browser.tsx
+++ b/apps/Documents/Components/Browser.tsx
@@ -53,6 +53,28 @@ export default class Browser extends Table<BrowserProps, BrowserState> {
     }
   }
 
+  componentDidMount() {
+    super.componentDidMount();
+    window.addEventListener('popstate', this.handlePopState);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('popstate', this.handlePopState);
+  }
+
+  handlePopState = (event: any) => {
+    if (event.state && event.state.folderUid) {
+      this.setState(event.state, () => { this.loadData(); });
+    } else {
+      this.setState({
+        recordId: 0,
+        folderUid: '_ROOT_',
+        path: [],
+        showFolderProperties: 0,
+      } as BrowserState, () => { this.loadData(); });
+    }
+  }
+
   loadData() {
     this.setState({loadingData: true}, () => {
       request.get(
@@ -85,12 +107,15 @@ export default class Browser extends Table<BrowserProps, BrowserState> {
   }
 
   changeFolder(newFolderUid: string, newPath: Array<string>) {
-    this.setState({
+    const newState = {
       recordId: 0,
       folderUid: newFolderUid,
       path: newPath,
       showFolderProperties: 0,
-    } as BrowserState, () => { this.loadData(); });
+    };
+    
+    window.history.pushState(newState, "", '?folderUid=' + newFolderUid);
+    this.setState(newState as BrowserState, () => { this.loadData(); });
   }
 
   createSubFolder() {


### PR DESCRIPTION
The browser Back button in Documents now navigates one folder level up instead of exiting the module entirely - folder navigation is now reflected in the URL. The raw technical permission error has been replaced with a clean, user-friendly message that fits within the dashboard layout. Dashboard color is no longer a required field, and users can now add multiple panels in a single modal session without closing and reopening between each one.

Fixed issues: https://github.com/hubleto/erp/issues/368 , https://github.com/hubleto/erp/issues/366 , https://github.com/hubleto/erp/issues/340